### PR TITLE
Add 1:1 spec tests; fix spec as a result

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
 			</ol>
 		</div>
 	</div>
-	<h1 class="version">Stage 2 Draft / October 3, 2016</h1>
+	<h1 class="version">Stage 2 Draft / November 4, 2016</h1>
 	<h1 class="title">Promise.prototype.finally</h1>
 
 	<emu-clause id="sec-promise.prototype.finally">
@@ -154,14 +154,10 @@
 					<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li>
 				<li>If
 					<emu-xref aoid="IsCallable"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
-					<emu-val>false</emu-val>, then
-					<ol>
-						<li>Return
-							<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>,
-							<emu-val>undefined</emu-val>,
-							<emu-val>undefined</emu-val>, <var>resultCapability</var>);</li>
-					</ol>
-				</li>
+					<emu-val>false</emu-val>, then return
+					<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>,
+					<emu-val>undefined</emu-val>,
+					<emu-val>undefined</emu-val>, <var>resultCapability</var>);</li>
 				<li>Let <var>thenFinally</var> be !
 					<emu-xref aoid="CreateThenFinally"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref>(<var>onFinally</var>).</li>
 				<li>Let <var>catchFinally</var> be !
@@ -189,7 +185,7 @@
 							<emu-val>undefined</emu-val>).</li>
 						<li>Let <var>promise</var> be !
 							<emu-xref aoid="PromiseResolve"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(
-							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>);</li>
+							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>).</li>
 						<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
 						<li>Let <var>promiseCapability</var> be !
 							<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(
@@ -220,13 +216,13 @@
 							<emu-val>undefined</emu-val>).</li>
 						<li>Let <var>promise</var> be !
 							<emu-xref aoid="PromiseResolve"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(
-							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>);</li>
+							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>).</li>
 						<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
 						<li>Let <var>promiseCapability</var> be !
 							<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(
 							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
 						<li>Return
-							<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>, <var>reason</var>,
+							<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>, <var>thrower</var>,
 							<emu-val>undefined</emu-val>, <var>promiseCapability</var>).
 						</li>
 					</ol>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
 			</ol>
 		</div>
 	</div>
-	<h1 class="version">Stage 2 Draft / November 4, 2016</h1>
+	<h1 class="version">Stage 2 Draft / November 15, 2016</h1>
 	<h1 class="title">Promise.prototype.finally</h1>
 
 	<emu-clause id="sec-promise.prototype.finally">
@@ -242,6 +242,17 @@
 				<li>If
 					<emu-xref aoid="Type"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is not Object, throw a
 					<emu-val>TypeError</emu-val> exception.</li>
+				<li>If
+					<emu-xref aoid="IsPromise"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>x</var>) is
+					<emu-val>true</emu-val>, then
+					<ol>
+						<li>Let <var>xConstructor</var> be ?
+							<emu-xref aoid="Get"><a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>x</var>, <code>"constructor"</code>).</li>
+						<li>If
+							<emu-xref aoid="SameValue"><a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>xConstructor</var>, <var>C</var>) is
+							<emu-val>true</emu-val>, return <var>x</var>.</li>
+					</ol>
+				</li>
 				<li>Return ?
 					<emu-xref aoid="PromiseResolve"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>x</var>).
 				</li>
@@ -260,17 +271,6 @@
 			<ol>
 				<li>Assert:
 					<emu-xref aoid="Type"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is Object.</li>
-				<li>If
-					<emu-xref aoid="IsPromise"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>x</var>) is
-					<emu-val>true</emu-val>, then
-					<ol>
-						<li>Let <var>xConstructor</var> be ?
-							<emu-xref aoid="Get"><a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>x</var>, <code>"constructor"</code>).</li>
-						<li>If
-							<emu-xref aoid="SameValue"><a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>xConstructor</var>, <var>C</var>) is
-							<emu-val>true</emu-val>, return <var>x</var>.</li>
-					</ol>
-				</li>
 				<li>Let <var>promiseCapability</var> be ?
 					<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<var>C</var>).</li>
 				<li>Perform ?

--- a/index.html
+++ b/index.html
@@ -17,15 +17,6 @@
 			"location": "",
 			"key": "Promise.prototype.finally ( _onFinally_ )"
 		}, {
-			"type": "clause",
-			"id": "sec-promisereaction-records",
-			"aoid": null,
-			"title": "PromiseReaction Records",
-			"number": "2",
-			"namespace": "<no location>",
-			"location": "",
-			"key": "PromiseReaction Records"
-		}, {
 			"type": "op",
 			"aoid": "PerformPromiseFinally",
 			"refId": "sec-performpromisefinally",
@@ -36,46 +27,46 @@
 			"id": "sec-performpromisefinally",
 			"aoid": "PerformPromiseFinally",
 			"title": "PerformPromiseFinally ( _promise_, _onFinally_, _resultCapability_ )",
-			"number": "3",
+			"number": "2",
 			"namespace": "<no location>",
 			"location": "",
 			"key": "PerformPromiseFinally ( _promise_, _onFinally_, _resultCapability_ )"
 		}, {
 			"type": "op",
-			"aoid": "PerformPromiseThen",
-			"refId": "sec-performpromisethen",
+			"aoid": "CreateThenFinally",
+			"refId": "sec-createthenfinally",
 			"location": "",
-			"key": "PerformPromiseThen"
+			"key": "CreateThenFinally"
 		}, {
 			"type": "clause",
-			"id": "sec-performpromisethen",
-			"aoid": "PerformPromiseThen",
-			"title": "PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_, _resultCapability_ )",
+			"id": "sec-createthenfinally",
+			"aoid": "CreateThenFinally",
+			"title": "CreateThenFinally ( _onFinally_ )",
+			"number": "3",
+			"namespace": "<no location>",
+			"location": "",
+			"key": "CreateThenFinally ( _onFinally_ )"
+		}, {
+			"type": "op",
+			"aoid": "CreateCatchFinally",
+			"refId": "sec-createcatchfinally",
+			"location": "",
+			"key": "CreateCatchFinally"
+		}, {
+			"type": "clause",
+			"id": "sec-createcatchfinally",
+			"aoid": "CreateCatchFinally",
+			"title": "CreateCatchFinally ( _onFinally_ )",
 			"number": "4",
 			"namespace": "<no location>",
 			"location": "",
-			"key": "PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_, _resultCapability_ )"
-		}, {
-			"type": "op",
-			"aoid": "EnqueuePromiseReactions",
-			"refId": "sec-enqueuepromisereactions",
-			"location": "",
-			"key": "EnqueuePromiseReactions"
-		}, {
-			"type": "clause",
-			"id": "sec-enqueuepromisereactions",
-			"aoid": "EnqueuePromiseReactions",
-			"title": "EnqueuePromiseReactions ( _promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_ )",
-			"number": "5",
-			"namespace": "<no location>",
-			"location": "",
-			"key": "EnqueuePromiseReactions ( _promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_ )"
+			"key": "CreateCatchFinally ( _onFinally_ )"
 		}, {
 			"type": "clause",
 			"id": "sec-promise.resolve",
 			"aoid": null,
 			"title": "Promise.resolve ( _x_ )",
-			"number": "6",
+			"number": "5",
 			"namespace": "<no location>",
 			"location": "",
 			"key": "Promise.resolve ( _x_ )"
@@ -90,25 +81,10 @@
 			"id": "sec-promise-resolve",
 			"aoid": "PromiseResolve",
 			"title": "PromiseResolve ( _C_, _x_ )",
-			"number": "7",
+			"number": "6",
 			"namespace": "<no location>",
 			"location": "",
 			"key": "PromiseResolve ( _C_, _x_ )"
-		}, {
-			"type": "op",
-			"aoid": "PromiseReactionJob",
-			"refId": "sec-promisereactionjob",
-			"location": "",
-			"key": "PromiseReactionJob"
-		}, {
-			"type": "clause",
-			"id": "sec-promisereactionjob",
-			"aoid": "PromiseReactionJob",
-			"title": "PromiseReactionJob ( _reaction_, _argument_ )",
-			"number": "8",
-			"namespace": "<no location>",
-			"location": "",
-			"key": "PromiseReactionJob ( _reaction_, _argument_ )"
 		}, {
 			"type": "clause",
 			"id": "sec-copyright-and-software-license",
@@ -118,14 +94,6 @@
 			"namespace": "<no location>",
 			"location": "",
 			"key": "Copyright & Software License"
-		}, {
-			"type": "table",
-			"id": "table-58",
-			"number": 1,
-			"caption": "Table 1: PromiseReaction Record Fields",
-			"namespace": "<no location>",
-			"location": "",
-			"key": "Table 1: PromiseReaction Record Fields"
 		}]
 	</script>
 </head>
@@ -139,18 +107,16 @@
 		<div id="menu-toc">
 			<ol class="toc">
 				<li><span class="item-toggle-none"></span><a href="#sec-promise.prototype.finally" title="Promise.prototype.finally ( _onFinally_ )"><span class="secnum">1</span> Promise.prototype.finally ( <var>onFinally</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promisereaction-records" title="PromiseReaction Records"><span class="secnum">2</span> PromiseReaction Records</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-performpromisefinally" title="PerformPromiseFinally ( _promise_, _onFinally_, _resultCapability_ )"><span class="secnum">3</span> PerformPromiseFinally ( <var>promise</var>, <var>onFinally</var>, <var>resultCapability</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-performpromisethen" title="PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_, _resultCapability_ )"><span class="secnum">4</span> PerformPromiseThen ( <var>promise</var>, <var>onFulfilled</var>, <var>onRejected</var>, <var>resultCapability</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-enqueuepromisereactions" title="EnqueuePromiseReactions ( _promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_ )"><span class="secnum">5</span> EnqueuePromiseReactions ( <var>promise</var>, <var>fulfillReaction</var>, <var>rejectReaction</var>, <var>resultCapability</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promise.resolve" title="Promise.resolve ( _x_ )"><span class="secnum">6</span> Promise.resolve ( <var>x</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promise-resolve" title="PromiseResolve ( _C_, _x_ )"><span class="secnum">7</span> PromiseResolve ( <var>C</var>, <var>x</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promisereactionjob" title="PromiseReactionJob ( _reaction_, _argument_ )"><span class="secnum">8</span> PromiseReactionJob ( <var>reaction</var>, <var>argument</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-performpromisefinally" title="PerformPromiseFinally ( _promise_, _onFinally_, _resultCapability_ )"><span class="secnum">2</span> PerformPromiseFinally ( <var>promise</var>, <var>onFinally</var>, <var>resultCapability</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-createthenfinally" title="CreateThenFinally ( _onFinally_ )"><span class="secnum">3</span> CreateThenFinally ( <var>onFinally</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-createcatchfinally" title="CreateCatchFinally ( _onFinally_ )"><span class="secnum">4</span> CreateCatchFinally ( <var>onFinally</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-promise.resolve" title="Promise.resolve ( _x_ )"><span class="secnum">5</span> Promise.resolve ( <var>x</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-promise-resolve" title="PromiseResolve ( _C_, _x_ )"><span class="secnum">6</span> PromiseResolve ( <var>C</var>, <var>x</var> )</a></li>
 				<li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li>
 			</ol>
 		</div>
 	</div>
-	<h1 class="version">Stage 2 Draft / July 29, 2016</h1>
+	<h1 class="version">Stage 2 Draft / October 3, 2016</h1>
 	<h1 class="title">Promise.prototype.finally</h1>
 
 	<emu-clause id="sec-promise.prototype.finally">
@@ -176,77 +142,8 @@
 		</emu-alg>
 	</emu-clause>
 
-	<emu-clause id="sec-promisereaction-records">
-		<h1><span class="secnum">2</span>PromiseReaction Records<span class="utils"><span class="anchor"><a href="#sec-promisereaction-records">#</a></span></span></h1>
-		<p>…</p>
-		<emu-table id="table-58" caption="PromiseReaction Record Fields">
-			<figure>
-				<figcaption>Table 1: PromiseReaction
-					<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> Fields</figcaption>
-				<table>
-					<tbody>
-						<tr>
-							<th>
-								Field Name
-
-							</th>
-							<th>
-								Value
-
-							</th>
-							<th>
-								Meaning
-
-							</th>
-						</tr>
-						<tr>
-							<td>
-								…
-
-							</td>
-							<td>
-								…
-
-							</td>
-							<td>
-								…
-
-							</td>
-						</tr>
-						<tr>
-							<td>
-								[[Type]]
-
-							</td>
-							<td>
-								Either <code>"Fulfill"</code>, <code>"Reject"</code>, or <code>"Finally"</code>.
-
-							</td>
-							<td>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								…
-
-							</td>
-							<td>
-								…
-
-							</td>
-							<td>
-								…
-
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			</figure>
-		</emu-table>
-	</emu-clause>
-
 	<emu-clause id="sec-performpromisefinally" aoid="PerformPromiseFinally">
-		<h1><span class="secnum">3</span>PerformPromiseFinally ( <var>promise</var>, <var>onFinally</var>, <var>resultCapability</var> )<span class="utils"><span class="anchor"><a href="#sec-performpromisefinally">#</a></span></span></h1>
+		<h1><span class="secnum">2</span>PerformPromiseFinally ( <var>promise</var>, <var>onFinally</var>, <var>resultCapability</var> )<span class="utils"><span class="anchor"><a href="#sec-performpromisefinally">#</a></span></span></h1>
 		<p>The abstract operation PerformPromiseFinally performs the “finally” operation on <var>promise</var> using <var>onFinally</var> as its settlement actions. The result is <var>resultCapability</var>'s promise.</p>
 		<emu-alg>
 			<ol>
@@ -259,98 +156,80 @@
 					<emu-xref aoid="IsCallable"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
 					<emu-val>false</emu-val>, then
 					<ol>
-						<li>Let <var>onFinally</var> be
-							<emu-val>undefined</emu-val>.</li>
+						<li>Return
+							<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>,
+							<emu-val>undefined</emu-val>,
+							<emu-val>undefined</emu-val>, <var>resultCapability</var>);</li>
 					</ol>
 				</li>
-				<li>Let <var>reaction</var> be the PromiseReaction { [[Capability]]: <var>resultCapability</var>, [[Type]]: <code>"Finally"</code>, [[Handler]]: <var>onFinally</var> }.</li>
+				<li>Let <var>thenFinally</var> be !
+					<emu-xref aoid="CreateThenFinally"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref>(<var>onFinally</var>).</li>
+				<li>Let <var>catchFinally</var> be !
+					<emu-xref aoid="CreateCatchFinally"><a href="#sec-createcatchfinally">CreateCatchFinally</a></emu-xref>(<var>onFinally</var>).</li>
 				<li>Return
-					<emu-xref aoid="EnqueuePromiseReactions"><a href="#sec-enqueuepromisereactions">EnqueuePromiseReactions</a></emu-xref>(<var>promise</var>, <var>reaction</var>, <var>reaction</var>, <var>resultCapability</var>).
+					<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>, <var>thenFinally</var>, <var>catchFinally</var>, <var>resultCapability</var>).
 				</li>
 			</ol>
 		</emu-alg>
 	</emu-clause>
 
-	<emu-clause id="sec-performpromisethen" aoid="PerformPromiseThen">
-		<h1><span class="secnum">4</span>PerformPromiseThen ( <var>promise</var>, <var>onFulfilled</var>, <var>onRejected</var>, <var>resultCapability</var> )<span class="utils"><span class="anchor"><a href="#sec-performpromisethen">#</a></span></span></h1>
-		<p>The abstract operation PerformPromiseThen performs the “then” operation on <var>promise</var> using <var>onFulfilled</var> and <var>onRejected</var> as its settlement actions. The result is <var>resultCapability</var>'s promise.</p>
+	<emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
+		<h1><span class="secnum">3</span>CreateThenFinally ( <var>onFinally</var> )<span class="utils"><span class="anchor"><a href="#sec-createthenfinally">#</a></span></span></h1>
+		<p>The abstract operation CreateThenFinally takes an <var>onFinally</var> function, and returns a callback function for use in
+			<emu-xref aoid="PerformPromiseFinally"><a href="#sec-performpromisefinally">PerformPromiseFinally</a></emu-xref>.</p>
 		<emu-alg>
 			<ol>
 				<li>Assert:
-					<emu-xref aoid="IsPromise"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>promise</var>) is
+					<emu-xref aoid="IsCallable"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
 					<emu-val>true</emu-val>.</li>
-				<li>Assert: <var>resultCapability</var> is a PromiseCapability
-					<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li>
-				<li>If
-					<emu-xref aoid="IsCallable"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFulfilled</var>) is
-					<emu-val>false</emu-val>, then
+				<li>Return a function that takes one argument, <var>value</var>, and when invoked, performs the following steps:
 					<ol>
-						<li>Let <var>onFulfilled</var> be
-							<emu-val>undefined</emu-val>.</li>
+						<li>Let <var>result</var> be ?
+							<emu-xref aoid="Call"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
+							<emu-val>undefined</emu-val>).</li>
+						<li>Let <var>promise</var> be !
+							<emu-xref aoid="PromiseResolve"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(
+							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>);</li>
+						<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
+						<li>Let <var>promiseCapability</var> be !
+							<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(
+							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
+						<li>Return
+							<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>, <var>valueThunk</var>,
+							<emu-val>undefined</emu-val>, <var>promiseCapability</var>).
+						</li>
 					</ol>
-				</li>
-				<li>If
-					<emu-xref aoid="IsCallable"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onRejected</var>) is
-					<emu-val>false</emu-val>, then
-					<ol>
-						<li>Let <var>onRejected</var> be
-							<emu-val>undefined</emu-val>.</li>
-					</ol>
-				</li>
-				<li>Let <var>fulfillReaction</var> be the PromiseReaction { [[Capability]]: <var>resultCapability</var>, [[Type]]: <code>"Fulfill"</code>, [[Handler]]: <var>onFulfilled</var> }.</li>
-				<li>Let <var>rejectReaction</var> be the PromiseReaction { [[Capability]]: <var>resultCapability</var>, [[Type]]: <code>"Reject"</code>, [[Handler]]: <var>onRejected</var> }.</li>
-				<li>Return
-					<emu-xref aoid="EnqueuePromiseReactions"><a href="#sec-enqueuepromisereactions">EnqueuePromiseReactions</a></emu-xref>(<var>promise</var>, <var>fulfillReaction</var>, <var>rejectReaction</var>, <var>resultCapability</var>).
 				</li>
 			</ol>
 		</emu-alg>
 	</emu-clause>
 
-	<emu-clause id="sec-enqueuepromisereactions" aoid="EnqueuePromiseReactions">
-		<h1><span class="secnum">5</span>EnqueuePromiseReactions ( <var>promise</var>, <var>fulfillReaction</var>, <var>rejectReaction</var>, <var>resultCapability</var> )<span class="utils"><span class="anchor"><a href="#sec-enqueuepromisereactions">#</a></span></span></h1>
-		<p>The abstract operation EnqueuePromiseReactions enqueues PromiseJobs with the provided PromiseReaction Records on <var>promise</var>. The result is <var>resultCapability</var>'s promise.</p>
+	<emu-clause id="sec-createcatchfinally" aoid="CreateCatchFinally">
+		<h1><span class="secnum">4</span>CreateCatchFinally ( <var>onFinally</var> )<span class="utils"><span class="anchor"><a href="#sec-createcatchfinally">#</a></span></span></h1>
+		<p>The abstract operation CreateCatchFinally takes an <var>onFinally</var> function, and returns a callback function for use in
+			<emu-xref aoid="PerformPromiseFinally"><a href="#sec-performpromisefinally">PerformPromiseFinally</a></emu-xref>.</p>
 		<emu-alg>
 			<ol>
 				<li>Assert:
-					<emu-xref aoid="IsPromise"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>promise</var>) is
+					<emu-xref aoid="IsCallable"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
 					<emu-val>true</emu-val>.</li>
-				<li>Assert: <var>resultCapability</var> is a PromiseCapability
-					<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li>
-				<li>Assert: <var>fulfillReaction</var> is a PromiseReaction
-					<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li>
-				<li>Assert: <var>rejectReaction</var> is a PromiseReaction
-					<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li>
-				<li>If <var>promise</var>.[[PromiseState]] is <code>"pending"</code>, then
+				<li>Return a function that takes one argument, <var>reason</var>, and when invoked, performs the following steps:
 					<ol>
-						<li>Append <var>fulfillReaction</var> as the last element of the
-							<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> that is <var>promise</var>.[[PromiseFulfillReactions]].</li>
-						<li>Append <var>rejectReaction</var> as the last element of the
-							<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> that is <var>promise</var>.[[PromiseRejectReactions]].</li>
+						<li>Let <var>result</var> be ?
+							<emu-xref aoid="Call"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
+							<emu-val>undefined</emu-val>).</li>
+						<li>Let <var>promise</var> be !
+							<emu-xref aoid="PromiseResolve"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(
+							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>);</li>
+						<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
+						<li>Let <var>promiseCapability</var> be !
+							<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(
+							<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
+						<li>Return
+							<emu-xref aoid="PerformPromiseThen"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>, <var>reason</var>,
+							<emu-val>undefined</emu-val>, <var>promiseCapability</var>).
+						</li>
 					</ol>
-				</li>
-				<li>Else if <var>promise</var>.[[PromiseState]] is <code>"fulfilled"</code>, then
-					<ol>
-						<li>Let <var>value</var> be <var>promise</var>.[[PromiseResult]].</li>
-						<li>Perform
-							<emu-xref aoid="EnqueueJob"><a href="https://tc39.github.io/ecma262/#sec-enqueuejob">EnqueueJob</a></emu-xref>(<code>"PromiseJobs"</code>,
-							<emu-xref aoid="PromiseReactionJob"><a href="#sec-promisereactionjob">PromiseReactionJob</a></emu-xref>, « <var>fulfillReaction</var>, <var>value</var> »).</li>
-					</ol>
-				</li>
-				<li>Else,
-					<ol>
-						<li>Assert: <var>promise</var>.[[PromiseState]] is <code>"rejected"</code>.</li>
-						<li>Let <var>reason</var> be <var>promise</var>.[[PromiseResult]].</li>
-						<li>If <var>promise</var>.[[PromiseIsHandled]] is
-							<emu-val>false</emu-val>, perform
-							<emu-xref aoid="HostPromiseRejectionTracker"><a href="https://tc39.github.io/ecma262/#sec-host-promise-rejection-tracker">HostPromiseRejectionTracker</a></emu-xref>(<var>promise</var>, <code>"handle"</code>).</li>
-						<li>Perform
-							<emu-xref aoid="EnqueueJob"><a href="https://tc39.github.io/ecma262/#sec-enqueuejob">EnqueueJob</a></emu-xref>(<code>"PromiseJobs"</code>,
-							<emu-xref aoid="PromiseReactionJob"><a href="#sec-promisereactionjob">PromiseReactionJob</a></emu-xref>, « <var>rejectReaction</var>, <var>reason</var> »).</li>
-					</ol>
-				</li>
-				<li>Set <var>promise</var>.[[PromiseIsHandled]] to
-					<emu-val>true</emu-val>.</li>
-				<li>Return <var>resultCapability</var>.[[Promise]].
 				</li>
 			</ol>
 		</emu-alg>
@@ -358,7 +237,7 @@
 
 	<!-- es6num="25.4.4.5" -->
 	<emu-clause id="sec-promise.resolve">
-		<h1><span class="secnum">6</span>Promise.resolve ( <var>x</var> )<span class="utils"><span class="anchor"><a href="#sec-promise.resolve">#</a></span></span></h1>
+		<h1><span class="secnum">5</span>Promise.resolve ( <var>x</var> )<span class="utils"><span class="anchor"><a href="#sec-promise.resolve">#</a></span></span></h1>
 		<p>The <code>resolve</code> function returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
 		<emu-alg>
 			<ol>
@@ -379,7 +258,7 @@
 	</emu-clause>
 
 	<emu-clause id="sec-promise-resolve" aoid="PromiseResolve">
-		<h1><span class="secnum">7</span>PromiseResolve ( <var>C</var>, <var>x</var> )<span class="utils"><span class="anchor"><a href="#sec-promise-resolve">#</a></span></span></h1>
+		<h1><span class="secnum">6</span>PromiseResolve ( <var>C</var>, <var>x</var> )<span class="utils"><span class="anchor"><a href="#sec-promise-resolve">#</a></span></span></h1>
 		<p>The abstract operation PromiseResolve, given a constructor and a value, returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
 		<emu-alg>
 			<ol>
@@ -402,78 +281,6 @@
 					<emu-xref aoid="Call"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]],
 					<emu-val>undefined</emu-val>, « <var>x</var> »).</li>
 				<li>Return <var>promiseCapability</var>.[[Promise]].
-				</li>
-			</ol>
-		</emu-alg>
-	</emu-clause>
-
-	<!-- es6num="25.4.2.1" -->
-	<emu-clause id="sec-promisereactionjob" aoid="PromiseReactionJob">
-		<h1><span class="secnum">8</span>PromiseReactionJob ( <var>reaction</var>, <var>argument</var> )<span class="utils"><span class="anchor"><a href="#sec-promisereactionjob">#</a></span></span></h1>
-		<p>The job PromiseReactionJob with parameters <var>reaction</var> and <var>argument</var> applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler.</p>
-		<emu-alg>
-			<ol>
-				<li>Assert: <var>reaction</var> is a PromiseReaction
-					<emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li>
-				<li>Let <var>promiseCapability</var> be <var>reaction</var>.[[Capability]].</li>
-				<li>Let <var>type</var> be <var>reaction</var>.[[Type]].</li>
-				<li>Let <var>handler</var> be <var>reaction</var>.[[Handler]].</li>
-				<li>If <var>handler</var> is
-					<emu-val>undefined</emu-val>, then
-					<ol>
-						<li>If <var>type</var> is <code>"Fulfill"</code>, let <var>handlerResult</var> be
-							<emu-xref aoid="NormalCompletion"><a href="https://tc39.github.io/ecma262/#sec-normalcompletion">NormalCompletion</a></emu-xref>(<var>argument</var>).</li>
-						<li>Else if <var>type</var> is <code>"Reject"</code>, let <var>handlerResult</var> be
-							<emu-xref aoid="Completion"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">Completion</a></emu-xref>{[[Type]]:
-							<emu-const>throw</emu-const>, [[Value]]: <var>argument</var>, [[Target]]:
-							<emu-const>empty</emu-const>}.</li>
-						<li>Else if <var>type</var> is <code>"Finally"</code>, let <var>handlerResult</var> be
-							<emu-xref aoid="NormalCompletion"><a href="https://tc39.github.io/ecma262/#sec-normalcompletion">NormalCompletion</a></emu-xref>(<var>argument</var>).</li>
-						<li>Assert: <var>handlerResult</var> is defined.</li>
-					</ol>
-				</li>
-				<li>Else if <var>type</var> is <code>"Finally"</code>, then
-					<ol>
-						<li>let <var>handlerResult</var> be
-							<emu-xref aoid="Call"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>handler</var>,
-							<emu-val>undefined</emu-val>, « »).</li>
-						<li>If <var>handlerResult</var> is not an
-							<emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then
-							<ol>
-								<li>Let <var>handlerPromise</var> be ?
-									<emu-xref aoid="PromiseResolve"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(
-									<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>handlerResult</var>.[[Value]]).</li>
-								<li>Let <var>argumentThunk</var> be equivalent to a function that returns <var>argument</var>.</li>
-								<li>Let <var>finalCapability</var> be ?
-									<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(
-									<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
-								<li>Return ?
-									<emu-xref aoid="PerformPromiseThen"><a href="#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>handlerPromise</var>, <var>argumentThunk</var>,
-									<emu-val>undefined</emu-val>, <var>finalCapability</var>).</li>
-							</ol>
-						</li>
-					</ol>
-				</li>
-				<li>Else, let <var>handlerResult</var> be
-					<emu-xref aoid="Call"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>handler</var>,
-					<emu-val>undefined</emu-val>, « <var>argument</var> »).</li>
-				<li>If <var>handlerResult</var> is an
-					<emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then
-					<ol>
-						<li>Let <var>status</var> be
-							<emu-xref aoid="Call"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]],
-							<emu-val>undefined</emu-val>, « <var>handlerResult</var>.[[Value]] »).</li>
-					</ol>
-				</li>
-				<li>Else,
-					<ol>
-						<li>Let <var>status</var> be
-							<emu-xref aoid="Call"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]],
-							<emu-val>undefined</emu-val>, « <var>handlerResult</var>.[[Value]] »).</li>
-					</ol>
-				</li>
-				<li>Return
-					<emu-xref aoid="Completion"><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">Completion</a></emu-xref>(<var>status</var>).
 				</li>
 			</ol>
 		</emu-alg>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 	"description": "ECMAScript spec proposal for Promise#finally",
 	"scripts": {
 		"build": "ecmarkup spec.emu --js=spec.js --css=spec.css | js-beautify -f - --type=html -t > index.html",
-		"prepublish": "in-install || (npm run build && not-in-publish || (echo >&2 'no publishing' && exit 255))"
+		"prepublish": "in-install || (npm run build && not-in-publish || (echo >&2 'no publishing' && exit 255))",
+		"test": "npm run test:aplus && npm run test:finally",
+		"test:aplus": "promises-aplus-tests test/adapter",
+		"test:finally": "mocha test/test"
 	},
 	"repository": {
 		"type": "git",
@@ -28,10 +31,14 @@
 		"url": "https://github.com/ljharb/proposal-promise-finally/issues"
 	},
 	"homepage": "https://github.com/ljharb/proposal-promise-finally#readme",
-	"dependencies": {},
+	"dependencies": {
+		"especially": "^2.0.1"
+	},
 	"devDependencies": {
 		"ecmarkup": "^3.2.6",
+		"in-publish": "^2.0.0",
 		"js-beautify": "^1.6.3",
-		"in-publish": "^2.0.0"
+		"mocha": "^3.1.0",
+		"promises-aplus-tests": "^2.1.2"
 	}
 }

--- a/spec.emu
+++ b/spec.emu
@@ -27,8 +27,7 @@ contributors: Jordan Harband
 	<emu-alg>
 		1. Assert: IsPromise(_promise_) is *true*.
 		1. Assert: _resultCapability_ is a PromiseCapability Record.
-		1. If IsCallable(_onFinally_) is *false*, then
-			1. Return PerformPromiseThen(_promise_, *undefined*, *undefined*, _resultCapability_);
+		1. If IsCallable(_onFinally_) is *false*, then return PerformPromiseThen(_promise_, *undefined*, *undefined*, _resultCapability_);
 		1. Let _thenFinally_ be ! CreateThenFinally(_onFinally_).
 		1. Let _catchFinally_ be ! CreateCatchFinally(_onFinally_).
 		1. Return PerformPromiseThen(_promise_, _thenFinally_, _catchFinally_, _resultCapability_).
@@ -42,7 +41,7 @@ contributors: Jordan Harband
 		1. Assert: IsCallable(_onFinally_) is *true*.
 		1. Return a function that takes one argument, _value_, and when invoked, performs the following steps:
 			1. Let _result_ be ? Call(_onFinally_, *undefined*).
-			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
 			1. Let _valueThunk_ be equivalent to a function that returns _value_.
 			1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
 			1. Return PerformPromiseThen(_promise_, _valueThunk_, *undefined*, _promiseCapability_).
@@ -56,10 +55,10 @@ contributors: Jordan Harband
 		1. Assert: IsCallable(_onFinally_) is *true*.
 		1. Return a function that takes one argument, _reason_, and when invoked, performs the following steps:
 			1. Let _result_ be ? Call(_onFinally_, *undefined*).
-			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
 			1. Let _thrower_ be equivalent to a function that throws _reason_.
 			1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-			1. Return PerformPromiseThen(_promise_, _reason_, *undefined*, _promiseCapability_).
+			1. Return PerformPromiseThen(_promise_, _thrower_, *undefined*, _promiseCapability_).
 	</emu-alg>
 </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -21,60 +21,6 @@ contributors: Jordan Harband
 	</emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-promisereaction-records">
-	<h1>PromiseReaction Records</h1>
-	<p>…</p>
-	<emu-table id="table-58" caption="PromiseReaction Record Fields">
-		<table>
-			<tbody>
-			<tr>
-				<th>
-					Field Name
-				</th>
-				<th>
-					Value
-				</th>
-				<th>
-					Meaning
-				</th>
-			</tr>
-			<tr>
-				<td>
-					…
-				</td>
-				<td>
-					…
-				</td>
-				<td>
-					…
-				</td>
-			</tr>
-			<tr>
-				<td>
-					[[Type]]
-				</td>
-				<td>
-					Either `"Fulfill"`, `"Reject"`, or `"Finally"`.
-				</td>
-				<td>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					…
-				</td>
-				<td>
-					…
-				</td>
-				<td>
-					…
-				</td>
-			</tr>
-			</tbody>
-		</table>
-	</emu-table>
-</emu-clause>
-
 <emu-clause id="sec-performpromisefinally" aoid="PerformPromiseFinally">
 	<h1>PerformPromiseFinally ( _promise_, _onFinally_, _resultCapability_ )</h1>
 	<p>The abstract operation PerformPromiseFinally performs the &ldquo;finally&rdquo; operation on _promise_ using _onFinally_ as its settlement actions. The result is _resultCapability_'s promise.</p>
@@ -82,49 +28,38 @@ contributors: Jordan Harband
 		1. Assert: IsPromise(_promise_) is *true*.
 		1. Assert: _resultCapability_ is a PromiseCapability Record.
 		1. If IsCallable(_onFinally_) is *false*, then
-			1. Let _onFinally_ be *undefined*.
-		1. Let _reaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Finally"`, [[Handler]]: _onFinally_ }.
-		1. Return EnqueuePromiseReactions(_promise_, _reaction_, _reaction_, _resultCapability_).
+			1. Return PerformPromiseThen(_promise_, *undefined*, *undefined*, _resultCapability_);
+		1. Let _thenFinally_ be ! CreateThenFinally(_onFinally_).
+		1. Let _catchFinally_ be ! CreateCatchFinally(_onFinally_).
+		1. Return PerformPromiseThen(_promise_, _thenFinally_, _catchFinally_, _resultCapability_).
 	</emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-performpromisethen" aoid="PerformPromiseThen">
-	<h1>PerformPromiseThen ( _promise_, _onFulfilled_, _onRejected_, _resultCapability_ )</h1>
-	<p>The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. The result is _resultCapability_'s promise.</p>
+<emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
+	<h1>CreateThenFinally ( _onFinally_ )</h1>
+	<p>The abstract operation CreateThenFinally takes an _onFinally_ function, and returns a callback function for use in PerformPromiseFinally.</p>
 	<emu-alg>
-		1. Assert: IsPromise(_promise_) is *true*.
-		1. Assert: _resultCapability_ is a PromiseCapability Record.
-		1. If IsCallable(_onFulfilled_) is *false*, then
-			1. Let _onFulfilled_ be *undefined*.
-		1. If IsCallable(_onRejected_) is *false*, then
-			1. Let _onRejected_ be *undefined*.
-		1. Let _fulfillReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
-		1. Let _rejectReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
-		1. Return EnqueuePromiseReactions(_promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_).
+		1. Assert: IsCallable(_onFinally_) is *true*.
+		1. Return a function that takes one argument, _value_, and when invoked, performs the following steps:
+			1. Let _result_ be ? Call(_onFinally_, *undefined*).
+			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+			1. Let _valueThunk_ be equivalent to a function that returns _value_.
+			1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+			1. Return PerformPromiseThen(_promise_, _valueThunk_, *undefined*, _promiseCapability_).
 	</emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-enqueuepromisereactions" aoid="EnqueuePromiseReactions">
-	<h1>EnqueuePromiseReactions ( _promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_ )</h1>
-	<p>The abstract operation EnqueuePromiseReactions enqueues PromiseJobs with the provided PromiseReaction Records on _promise_. The result is _resultCapability_'s promise.</p>
+<emu-clause id="sec-createcatchfinally" aoid="CreateCatchFinally">
+	<h1>CreateCatchFinally ( _onFinally_ )</h1>
+	<p>The abstract operation CreateCatchFinally takes an _onFinally_ function, and returns a callback function for use in PerformPromiseFinally.</p>
 	<emu-alg>
-		1. Assert: IsPromise(_promise_) is *true*.
-		1. Assert: _resultCapability_ is a PromiseCapability Record.
-		1. Assert: _fulfillReaction_ is a PromiseReaction Record.
-		1. Assert: _rejectReaction_ is a PromiseReaction Record.
-		1. If _promise_.[[PromiseState]] is `"pending"`, then
-			1. Append _fulfillReaction_ as the last element of the List that is _promise_.[[PromiseFulfillReactions]].
-			1. Append _rejectReaction_ as the last element of the List that is _promise_.[[PromiseRejectReactions]].
-		1. Else if _promise_.[[PromiseState]] is `"fulfilled"`, then
-			1. Let _value_ be _promise_.[[PromiseResult]].
-			1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _fulfillReaction_, _value_ &raquo;).
-		1. Else,
-			1. Assert: _promise_.[[PromiseState]] is `"rejected"`.
-			1. Let _reason_ be _promise_.[[PromiseResult]].
-			1. If _promise_.[[PromiseIsHandled]] is *false*, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
-			1. Perform EnqueueJob(`"PromiseJobs"`, PromiseReactionJob, &laquo; _rejectReaction_, _reason_ &raquo;).
-		1. Set _promise_.[[PromiseIsHandled]] to *true*.
-		1. Return _resultCapability_.[[Promise]].
+		1. Assert: IsCallable(_onFinally_) is *true*.
+		1. Return a function that takes one argument, _reason_, and when invoked, performs the following steps:
+			1. Let _result_ be ? Call(_onFinally_, *undefined*).
+			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+			1. Let _thrower_ be equivalent to a function that throws _reason_.
+			1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+			1. Return PerformPromiseThen(_promise_, _reason_, *undefined*, _promiseCapability_).
 	</emu-alg>
 </emu-clause>
 
@@ -153,35 +88,5 @@ contributors: Jordan Harband
 		1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
 		1. Perform ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _x_ &raquo;).
 		1. Return _promiseCapability_.[[Promise]].
-	</emu-alg>
-</emu-clause>
-
-<!-- es6num="25.4.2.1" -->
-<emu-clause id="sec-promisereactionjob" aoid="PromiseReactionJob">
-	<h1>PromiseReactionJob ( _reaction_, _argument_ )</h1>
-	<p>The job PromiseReactionJob with parameters _reaction_ and _argument_ applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler.</p>
-	<emu-alg>
-		1. Assert: _reaction_ is a PromiseReaction Record.
-		1. Let _promiseCapability_ be _reaction_.[[Capability]].
-		1. Let _type_ be _reaction_.[[Type]].
-		1. Let _handler_ be _reaction_.[[Handler]].
-		1. If _handler_ is *undefined*, then
-			1. If _type_ is `"Fulfill"`, let _handlerResult_ be NormalCompletion(_argument_).
-			1. Else if _type_ is `"Reject"`, let _handlerResult_ be Completion{[[Type]]: ~throw~, [[Value]]: _argument_, [[Target]]: ~empty~}.
-			1. Else if _type_ is `"Finally"`, let _handlerResult_ be NormalCompletion(_argument_).
-			1. Assert: _handlerResult_ is defined.
-		1. Else if _type_ is `"Finally"`, then
-			1. let _handlerResult_ be Call(_handler_, *undefined*, &laquo; &raquo;).
-			1. If _handlerResult_ is not an abrupt completion, then
-				1. Let _handlerPromise_ be ? PromiseResolve(%Promise%, _handlerResult_.[[Value]]).
-				1. Let _argumentThunk_ be equivalent to a function that returns _argument_.
-				1. Let _finalCapability_ be ? NewPromiseCapability(%Promise%).
-				1. Return ? PerformPromiseThen(_handlerPromise_, _argumentThunk_, *undefined*, _finalCapability_).
-		1. Else, let _handlerResult_ be Call(_handler_, *undefined*, &laquo; _argument_ &raquo;).
-		1. If _handlerResult_ is an abrupt completion, then
-			1. Let _status_ be Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
-		1. Else,
-			1. Let _status_ be Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _handlerResult_.[[Value]] &raquo;).
-		1. Return Completion(_status_).
 	</emu-alg>
 </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -69,6 +69,9 @@ contributors: Jordan Harband
 	<emu-alg>
 		1. Let _C_ be the *this* value.
 		1. If Type(_C_) is not Object, throw a *TypeError* exception.
+		1. If IsPromise(_x_) is *true*, then
+			1. Let _xConstructor_ be ? Get(_x_, `"constructor"`).
+			1. If SameValue(_xConstructor_, _C_) is *true*, return _x_.
 		1. Return ? PromiseResolve(_C_, _x_).
 	</emu-alg>
 	<emu-note>
@@ -81,9 +84,6 @@ contributors: Jordan Harband
 	<p>The abstract operation PromiseResolve, given a constructor and a value, returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
 	<emu-alg>
 		1. Assert: Type(_C_) is Object.
-		1. If IsPromise(_x_) is *true*, then
-			1. Let _xConstructor_ be ? Get(_x_, `"constructor"`).
-			1. If SameValue(_xConstructor_, _C_) is *true*, return _x_.
 		1. Let _promiseCapability_ be ? NewPromiseCapability(_C_).
 		1. Perform ? Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _x_ &raquo;).
 		1. Return _promiseCapability_.[[Promise]].

--- a/spec.md
+++ b/spec.md
@@ -7,77 +7,38 @@ When the `finally` method is called with argument _onFinally_, the following ste
   1. Let _resultCapability_ be ? <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-newpromisecapability">NewPromiseCapability</a>(_C_).
   1. Return <a href="#performpromisefinally--promise-onfinally-resultcapability-">PerformPromiseFinally</a>(_promise_, _onFinally_, _resultCapability_).
 
-## PromiseReaction Records
-
-…
-<table>
-	<tbody>
-	<tr>
-		<th>Field Name</th>
-		<th>Value</th>
-		<th>Meaning</th>
-	</tr>
-	<tr>
-		<td>…</td>
-		<td>…</td>
-		<td>…</td>
-	</tr>
-	<tr>
-		<td>[[Type]]</td>
-		<td>Either <b>"Fulfill"</b>, <b>"Reject"</b>, or <b>"Finally"</b>.</td>
-		<td></td>
-	</tr>
-	<tr>
-		<td>…</td>
-		<td>…</td>
-		<td>…</td>
-	</tr>
-	</tbody>
-</table>
-
 ## PerformPromiseFinally ( _promise_, _onFinally_, _resultCapability_ )
 
 The abstract operation PerformPromiseFinally performs the &ldquo;finally&rdquo; operation on _promise_ using _onFinally_ as its settlement actions. The result is _resultCapability_'s promise.
   1. Assert: IsPromise(_promise_) is **true**.
   1. Assert: _resultCapability_ is a PromiseCapability Record.
   1. If <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-iscallable">IsCallable</a>(_onFinally_) is **false**, then
-    1. Let _onFinally_ be **undefined**.
-  1. Let _reaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Finally"`, [[Handler]]: _onFinally_ }.
-  1. Return <a href="#enqueuepromisereactions--promise-fulfillreaction-rejectreaction-resultcapability-">EnqueuePromiseReactions</a>(_promise_, _reaction_, _reaction_, _resultCapability_).
+    1. Return <a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a>(_promise_, **undefined**, **undefined**, _resultCapability_).
+  1. Let _thenFinally_ be CreateThenFinally(_onFinally_).
+  1. Let _catchFinally_ be CreateCatchFinally(_onFinally_).
+  1. Return <a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a>(_promise_, _thenFinally_, _catchFinally_, _resultCapability_).
 
-## PerformPromiseThen ( _promise_, _oInFulfilled_, _onRejected_, _resultCapability_ )
+## CreateThenFinally ( _onFinally_ )
 
-The abstract operation PerformPromiseThen performs the &ldquo;then&rdquo; operation on _promise_ using _onFulfilled_ and _onRejected_ as its settlement actions. The result is _resultCapability_'s promise.
-  1. Assert: IsPromise(_promise_) is **true**.
-  1. Assert: _resultCapability_ is a PromiseCapability Record.
-  1. If <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-iscallable">IsCallable</a>(_onFulfilled_) is **false**, then
-    1. Let _onFulfilled_ be **undefined**.
-  1. If <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-iscallable">IsCallable</a>(_onRejected_) is **false**, then
-    1. Let _onRejected_ be **undefined**.
-  1. Let _fulfillReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Fulfill"`, [[Handler]]: _onFulfilled_ }.
-  1. Let _rejectReaction_ be the PromiseReaction { [[Capability]]: _resultCapability_, [[Type]]: `"Reject"`, [[Handler]]: _onRejected_ }.
-  1. Return <a href="#enqueuepromisereactions--promise-fulfillreaction-rejectreaction-resultcapability-">EnqueuePromiseReactions</a>(_promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_).
+The abstract operation CreateThenFinally takes an _onFinally_ function, and returns a callback function for use in PerformPromiseFinally.
+  1. Assert: IsCallable(_onFinally_) is *true*.
+  1. Return a function that takes one argument, _value_, and when invoked, performs the following steps:
+    1. Let _result_ be ? Call(_onFinally_, *undefined*).
+    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+    1. Let _valueThunk_ be equivalent to a function that returns _value_.
+    1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+    1. Return PerformPromiseThen(_promise_, _valueThunk_, *undefined*, _promiseCapability_).
 
-## EnqueuePromiseReactions ( _promise_, _fulfillReaction_, _rejectReaction_, _resultCapability_ )
+## CreateCatchFinally ( _onFinally_ )
 
-The abstract operation EnqueuePromiseReactions enqueues PromiseJobs with the provided PromiseReaction Record on _promise_. The result is _resultCapability_'s promise.
-  1. Assert: IsPromise(_promise_) is **true**.
-  1. Assert: _resultCapability_ is a PromiseCapability Record.
-  1. Assert: _fulfillReaction_ is a PromiseReaction Record.
-  1. Assert: _rejectReaction_ is a PromiseReaction Record.
-  1. If _promise_.[[PromiseState]] is `"pending"`, then
-    1. Append _fulfillReaction_ as the last element of the List that is _promise_.[[PromiseFulfillReactions]].
-    1. Append _rejectReaction_ as the last element of the List that is _promise_.[[PromiseRejectReactions]].
-  1. Else if _promise_.[[PromiseState]] is `"fulfilled"`, then
-    1. Let _value_ be _promise_.[[PromiseResult]].
-    1. Perform <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-enqueuejob">EnqueueJob</a>(`"PromiseJobs"`, <a href="#sec-promisereactionjob">PromiseReactionJob</a>, &laquo; _fulfillReaction_, _value_ &raquo;).
-  1. Else,
-    1. Assert: _promise_.[[PromiseState]] is `"rejected"`.
-    1. Let _reason_ be _promise_.[[PromiseResult]].
-    1. If _promise_.[[PromiseIsHandled]] is **false**, perform HostPromiseRejectionTracker(_promise_, `"handle"`).
-    1. Perform EnqueueJob(`"PromiseJobs"`, <a href="#sec-promisereactionjob">PromiseReactionJob</a>, &laquo; _rejectReaction_, _reason_ &raquo;).
-  1. Set _promise_.[[PromiseIsHandled]] to **true**.
-  1. Return _resultCapability_.[[Promise]].
+The abstract operation CreateCatchFinally takes an _onFinally_ function, and returns a callback function for use in PerformPromiseFinally.
+  1. Assert: IsCallable(_onFinally_) is *true*.
+  1. Return a function that takes one argument, _reason_, and when invoked, performs the following steps:
+    1. Let _result_ be ? Call(_onFinally_, *undefined*).
+    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+    1. Let _thrower_ be equivalent to a function that throws _reason_.
+    1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+    1. Return PerformPromiseThen(_promise_, _thrower_, *undefined*, _promiseCapability_).
 
 ## Promise.resolve ( _x_ )
 
@@ -97,30 +58,3 @@ The abstract operation PromiseResolve, given a constructor and a value, returns 
   1. Let _promiseCapability_ be ? <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-newpromisecapability">NewPromiseCapability</a>(_C_).
   1. Perform ? <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-call">Call</a>(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _x_ &raquo;).
   1. Return _promiseCapability_.[[Promise]].
-
-## PromiseReactionJob ( _reaction_, _argument_ )
-
-The job PromiseReactionJob with parameters _reaction_ and _argument_ applies the appropriate handler to the incoming value, and uses the handler's return value to resolve or reject the derived promise associated with that handler.
-  1. Assert: _reaction_ is a PromiseReaction Record.
-  1. Let _promiseCapability_ be _reaction_.[[Capability]].
-  1. Let _type_ be _reaction_.[[Type]].
-  1. Let _handler_ be _reaction_.[[Handler]].
-  1. If _handler_ is **undefined**, then
-    1. If _type_ is `"Fulfill"`, let _handlerResult_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-normalcompletion">NormalCompletion</a>(_argument_).
-    1. Else if _type_ is `"Reject"`, let _handlerResult_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-completion-record-specification-type">Completion</a>{[[Type]]: ~throw~, [[Value]]: _argument_, [[Target]]: ~empty~}.
-    1. Else if _type_ is `"Finally"`, let _handlerResult_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-normalcompletion">NormalCompletion</a>(_argument_).
-    1. Assert: _handlerResult_ is defined.
-  1. Else if _type_ is `"Finally"`, let _handlerResult_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-call">Call</a>(_handler_, **undefined**, &laquo; &raquo;).
-  1. Else if _type_ is `"Finally"`, then
-    1. let _handlerResult_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-call">Call</a>(_handler_, *undefined*, &laquo; &raquo;).
-    1. If _handlerResult_ is not an abrupt completion, then
-      1. Let _handlerPromise_ be ? PromiseResolve(%Promise%, _handlerResult_.[[Value]]).
-      1. Let _argumentThunk_ be equivalent to a function that returns _argument_.
-      1. Let _finalCapability_ be ? <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-newpromisecapability">NewPromiseCapability</a>(%Promise%).
-      1. Return ? PerformPromiseThen(_handlerPromise_, _argumentThunk_, *undefined*, _finalCapability_).
-  1. Else, let _handlerResult_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-call">Call</a>(_handler_, **undefined**, &laquo; _argument_ &raquo;).
-  1. If _handlerResult_ is an <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-completion-record-specification-type">abrupt completion</a>, then
-    1. Let _status_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-call">Call</a>(_promiseCapability_.[[Reject]], **undefined**, &laquo; _handlerResult_.[[Value]] &raquo;).
-  1. Else,
-    1. Let _status_ be <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-call">Call</a>(_promiseCapability_.[[Resolve]], **undefined**, &laquo; _handlerResult_.[[Value]] &raquo;).
-  1. Return <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-completion-record-specification-type">Completion</a>(_status_).

--- a/spec.md
+++ b/spec.md
@@ -44,6 +44,9 @@ The abstract operation CreateCatchFinally takes an _onFinally_ function, and ret
 The `resolve` function returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.
   1. Let _C_ be the *this* value.
   1. If <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">Type</a>(_C_) is not Object, throw a *TypeError* exception.
+  1. If <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ispromise">IsPromise</a>(_x_) is *true*, then
+    1. Let _xConstructor_ be ? <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">Get</a>(_x_, `"constructor"`).
+    1. If SameValue(_xConstructor_, _C_) is *true*, return _x_.
   1. Return ? PromiseResolve(_C_, _x_).
 
 Note: the `resolve` function expects its *this* value to be a constructor function that supports the parameter conventions of the `Promise` constructor.
@@ -51,9 +54,6 @@ Note: the `resolve` function expects its *this* value to be a constructor functi
 ## PromiseResolve ( _C_, _x_ )
 The abstract operation PromiseResolve, given a constructor and a value, returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.
   1. Assert: <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">Type</a>(_C_) is Object.
-  1. If <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ispromise">IsPromise</a>(_x_) is *true*, then
-    1. Let _xConstructor_ be ? <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">Get</a>(_x_, `"constructor"`).
-    1. If SameValue(_xConstructor_, _C_) is *true*, return _x_.
   1. Let _promiseCapability_ be ? <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-newpromisecapability">NewPromiseCapability</a>(_C_).
   1. Perform ? <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-call">Call</a>(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _x_ &raquo;).
   1. Return _promiseCapability_.[[Promise]].

--- a/spec.md
+++ b/spec.md
@@ -12,8 +12,7 @@ When the `finally` method is called with argument _onFinally_, the following ste
 The abstract operation PerformPromiseFinally performs the &ldquo;finally&rdquo; operation on _promise_ using _onFinally_ as its settlement actions. The result is _resultCapability_'s promise.
   1. Assert: IsPromise(_promise_) is **true**.
   1. Assert: _resultCapability_ is a PromiseCapability Record.
-  1. If <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-iscallable">IsCallable</a>(_onFinally_) is **false**, then
-    1. Return <a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a>(_promise_, **undefined**, **undefined**, _resultCapability_).
+  1. If <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-iscallable">IsCallable</a>(_onFinally_) is **false**, then return <a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a>(_promise_, **undefined**, **undefined**, _resultCapability_).
   1. Let _thenFinally_ be CreateThenFinally(_onFinally_).
   1. Let _catchFinally_ be CreateCatchFinally(_onFinally_).
   1. Return <a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a>(_promise_, _thenFinally_, _catchFinally_, _resultCapability_).
@@ -24,7 +23,7 @@ The abstract operation CreateThenFinally takes an _onFinally_ function, and retu
   1. Assert: IsCallable(_onFinally_) is *true*.
   1. Return a function that takes one argument, _value_, and when invoked, performs the following steps:
     1. Let _result_ be ? Call(_onFinally_, *undefined*).
-    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
     1. Let _valueThunk_ be equivalent to a function that returns _value_.
     1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
     1. Return PerformPromiseThen(_promise_, _valueThunk_, *undefined*, _promiseCapability_).
@@ -35,7 +34,7 @@ The abstract operation CreateCatchFinally takes an _onFinally_ function, and ret
   1. Assert: IsCallable(_onFinally_) is *true*.
   1. Return a function that takes one argument, _reason_, and when invoked, performs the following steps:
     1. Let _result_ be ? Call(_onFinally_, *undefined*).
-    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_);
+    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
     1. Let _thrower_ be equivalent to a function that throws _reason_.
     1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
     1. Return PerformPromiseThen(_promise_, _thrower_, *undefined*, _promiseCapability_).

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -1,0 +1,14 @@
+var P = require('./promise');
+
+module.exports = {
+	resolved(x) { return P.resolve(x); },
+	rejected(e) { return P.reject(e); },
+	deferred() {
+		var deferred = {};
+		deferred.promise = new P((resolve, reject) => {
+			deferred.resolve = resolve;
+			deferred.reject = reject;
+		});
+		return deferred;
+	}
+};

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,555 @@
+global.foo = 0;
+global.id = 1;
+const {
+	Call,
+	EnqueueJob,
+	Get,
+	Invoke,
+	IsCallable,
+	IsConstructor,
+	SameValue,
+	SpeciesConstructor,
+	Type,
+} = require('especially/abstract-operations');
+const {
+	assert,
+	get_slot,
+	has_slot,
+	make_slots,
+	set_slot,
+} = require('especially/meta');
+const { '@@species': atAtSpecies } = require('especially/well-known-symbols');
+
+function IfAbruptRejectPromise(value, capability) {
+	// Usage: pass it exceptions; it only handles that case.
+	// Always use `return` before it, i.e. `try { ... } catch (e) { return IfAbruptRejectPromise(e, capability); }`.
+	Call(get_slot(capability, '[[Reject]]'), value);
+	return get_slot(capability, '[[Promise]]');
+}
+
+function CreateResolvingFunctions(promise) {
+	const alreadyResolved = {};
+	make_slots(alreadyResolved, [
+		'[[Value]]',
+	]);
+	set_slot(alreadyResolved, '[[Value]]', false);
+
+	function resolve(resolution) {
+		assert(has_slot(resolve, '[[Promise]]'));
+		const promise = get_slot(resolve, '[[Promise]]');
+		assert(Type(promise) === 'Object');
+
+		const alreadyResolved = get_slot(resolve, '[[AlreadyResolved]]');
+		if (get_slot(alreadyResolved, '[[Value]]') === true) {
+			return;
+		}
+
+		set_slot(alreadyResolved, '[[Value]]', true);
+
+		if (SameValue(resolution, promise) === true) {
+			const selfResolutionError = new TypeError('self resolution');
+			return RejectPromise(promise, selfResolutionError);
+		}
+
+		if (Type(resolution) !== 'Object') {
+			return FulfillPromise(promise, resolution);
+		}
+
+		let thenAction;
+		try {
+			thenAction = Get(resolution, 'then');
+		} catch (thenActionE) {
+			return RejectPromise(promise, thenActionE);
+		}
+
+		if (IsCallable(thenAction) === false) {
+			return FulfillPromise(promise, resolution);
+		}
+
+		EnqueueJob('PromiseJobs', PromiseResolveThenableJob, [promise, resolution, thenAction]);
+	}
+	make_slots(resolve, [
+		'[[Promise]]',
+		'[[AlreadyResolved]]',
+	]);
+	set_slot(resolve, '[[Promise]]', promise);
+	set_slot(resolve, '[[AlreadyResolved]]', alreadyResolved);
+
+	function reject(reason) {
+		assert(has_slot(reject, '[[Promise]]'));
+		const promise = get_slot(reject, '[[Promise]]');
+		assert(Type(promise) === 'Object');
+
+		const alreadyResolved = get_slot(reject, '[[AlreadyResolved]]');
+		if (get_slot(alreadyResolved, '[[Value]]') === true) {
+			return undefined;
+		}
+
+		set_slot(alreadyResolved, '[[Value]]', true);
+
+		return RejectPromise(promise, reason);
+	}
+	make_slots(reject, [
+		'[[Promise]]',
+		'[[AlreadyResolved]]',
+	]);
+	set_slot(reject, '[[Promise]]', promise);
+	set_slot(reject, '[[AlreadyResolved]]', alreadyResolved);
+
+	const record = {};
+	make_slots(record, [
+		'[[Resolve]]',
+		'[[Reject]]',
+	]);
+	set_slot(record, '[[Resolve]]', resolve);
+	set_slot(record, '[[Reject]]', reject);
+	return record;
+}
+
+function FulfillPromise(promise, value) {
+	assert(get_slot(promise, '[[PromiseState]]') === 'pending');
+
+	const reactions = get_slot(promise, '[[PromiseFulfillReactions]]');
+
+	set_slot(promise, '[[PromiseResult]]', value);
+	set_slot(promise, '[[PromiseFulfillReactions]]', undefined);
+	set_slot(promise, '[[PromiseRejectReactions]]', undefined);
+	set_slot(promise, '[[PromiseState]]', 'fulfilled');
+
+	return TriggerPromiseReactions(reactions, value);
+}
+
+function NewPromiseCapability(C) {
+	if (IsConstructor(C) === false) {
+		throw new TypeError('NewPromiseCapability only works on constructors');
+	}
+
+	const promiseCapability = {};
+	make_slots(promiseCapability, [
+		'[[Promise]]',
+		'[[Resolve]]',
+		'[[Reject]]',
+	]);
+	set_slot(promiseCapability, '[[Promise]]', undefined);
+	set_slot(promiseCapability, '[[Resolve]]', undefined);
+	set_slot(promiseCapability, '[[Reject]]', undefined);
+	function executor(resolve, reject) {
+		const promiseCapability = get_slot(executor, '[[Capability]]');
+
+		assert(IsPromiseCapabilityRecord(promiseCapability));
+
+		if (get_slot(promiseCapability, '[[Resolve]]') !== undefined) {
+			throw new TypeError('Promise capability must not have [[Resolve]] set when calling executor');
+		}
+		if (get_slot(promiseCapability, '[[Reject]]') !== undefined) {
+			throw new TypeError('Promise capability must not have [[Reject]] set when calling executor');
+		}
+
+		set_slot(promiseCapability, '[[Resolve]]', resolve);
+		set_slot(promiseCapability, '[[Reject]]', reject);
+
+		return undefined;
+	}
+	make_slots(executor, ['[[Capability]]']);
+	set_slot(executor, '[[Capability]]', promiseCapability);
+
+	const promise = new C(executor);
+	if (IsCallable(get_slot(promiseCapability, '[[Resolve]]')) === false) {
+		throw new TypeError('The given constructor did not correctly set a [[Resolve]] function on the promise capability');
+	}
+	if (IsCallable(get_slot(promiseCapability, '[[Reject]]')) === false) {
+		throw new TypeError('The given constructor did not correctly set a [[Reject]] function on the promise capability');
+	}
+
+	set_slot(promiseCapability, '[[Promise]]', promise);
+	return promiseCapability;
+}
+
+function IsPromiseCapabilityRecord(x) {
+	const promise = get_slot(x, '[[Promise]]');
+	if (promise !== undefined && !IsPromise(promise)) {
+		return false;
+	}
+
+	const resolve = get_slot(x, '[[Resolve]]');
+	const reject = get_slot(x, '[[Reject]]');
+	if (resolve !== undefined && !IsCallable(resolve)) {
+		return false;
+	}
+	if (reject !== undefined && !IsCallable(reject)) {
+		return false;
+	}
+
+	return true;
+}
+
+function IsPromiseReactionRecord(x) {
+	if (Type(x) !== 'Object') {
+		return false;
+	}
+
+	if (!has_slot(x, '[[Capability]]')) {
+		return false;
+	}
+	if (!has_slot(x, '[[Type]]')) {
+		return false;
+	}
+	const type = get_slot(x, '[[Type]]');
+	if (type !== 'Fulfill' && type !== 'Reject') {
+		return false;
+	}
+
+	if (!has_slot(x, '[[Handler]]')) {
+		return false;
+	}
+	const handler = get_slot(x, '[[Handler]]');
+	if (!IsCallable(handler) && handler !== undefined) {
+		return false;
+	}
+
+	return true;
+}
+
+function IsPromise(x) {
+	if (Type(x) !== 'Object') {
+		return false;
+	}
+
+	if (!has_slot(x, '[[PromiseState]]')) {
+		return false;
+	}
+
+	return true;
+}
+
+function RejectPromise(promise, reason) {
+	assert(get_slot(promise, '[[PromiseState]]') === 'pending');
+
+	const reactions = get_slot(promise, '[[PromiseRejectReactions]]');
+
+	set_slot(promise, '[[PromiseResult]]', reason);
+	set_slot(promise, '[[PromiseFulfillReactions]]', undefined);
+	set_slot(promise, '[[PromiseRejectReactions]]', undefined);
+	set_slot(promise, '[[PromiseState]]', 'rejected');
+
+	if (get_slot(promise, '[[PromiseIsHandled]]') === false) {
+		HostPromiseRejectionTracker(promise, 'reject');
+	}
+
+	return TriggerPromiseReactions(reactions, reason);
+}
+
+function TriggerPromiseReactions(reactions, argument) {
+	for (const reaction of reactions) {
+		EnqueueJob('PromiseJobs', PromiseReactionJob, [reaction, argument]);
+	}
+
+	return undefined;
+}
+
+function HostPromiseRejectionTracker(promise, operation) {
+	assert(IsPromise(promise));
+	assert(operation === 'reject' || operation === 'handle');
+}
+
+function NewCompletionRecord(type, value, target) {
+	const completionRecord = {};
+	make_slots(completionRecord, [
+		'[[Type]]',
+		'[[Value]]',
+		'[[Target]]',
+	]);
+	set_slot(completionRecord, '[[Type]]', type);
+	set_slot(completionRecord, '[[Value]]', value);
+	set_slot(completionRecord, '[[Target]]', target);
+	return completionRecord;
+}
+
+function isCompletionRecord(completionRecord) {
+	if (!has_slot(completionRecord, '[[Type]]') || !has_slot(completionRecord, '[[Value]]') || !has_slot(completionRecord, '[[Target]]')) {
+		return false;
+	}
+	const type = get_slot(completionRecord, '[[Type]]');
+	const possibleTypes = ['normal', 'break', 'continue', 'return', 'throw'];
+	if (!possibleTypes.includes(type)) {
+		return false;
+	}
+
+	const target = get_slot(completionRecord, '[[Target]]');
+	if (typeof target !== 'undefined' && typeof	target !== 'string') {
+		return false;
+	}
+	return true;
+}
+
+function NormalCompletion(value) {
+	return NewCompletionRecord('normal', value);
+}
+
+function AbruptCompletion(value) {
+	return NewCompletionRecord('throw', value);
+}
+
+function isAbruptCompletion(completionRecord) {
+	return isCompletionRecord(completionRecord) && get_slot(completionRecord, '[[Type]]') === 'throw';
+}
+
+function PromiseReactionJob(reaction, argument) {
+	assert(IsPromiseReactionRecord(reaction) === true);
+
+	const promiseCapability = get_slot(reaction, '[[Capability]]');
+	const type = get_slot(reaction, '[[Type]]');
+	const handler = get_slot(reaction, '[[Handler]]');
+
+	let handlerResult;
+	if (handler === undefined) {
+		if (type === 'Fulfill') {
+			handlerResult = NormalCompletion(argument);
+		} else {
+			assert(type === 'Reject');
+			handlerResult = AbruptCompletion(argument);
+		}
+	} else {
+		try {
+			handlerResult = NormalCompletion(Call(handler, undefined, [argument]));
+		} catch (callE) {
+			handlerResult = AbruptCompletion(callE);
+		}
+	}
+
+	let status;
+	if (isAbruptCompletion(handlerResult)) {
+		status = Call(get_slot(promiseCapability, '[[Reject]]'), undefined, [get_slot(handlerResult, '[[Value]]')]);
+	} else {
+		status = Call(get_slot(promiseCapability, '[[Resolve]]'), undefined, [get_slot(handlerResult, '[[Value]]')]);
+	}
+	return status;
+}
+
+function PromiseResolveThenableJob(promiseToResolve, thenable, then) {
+	const resolvingFunctions = CreateResolvingFunctions(promiseToResolve);
+
+	try {
+		Call(then, thenable, [
+			get_slot(resolvingFunctions, '[[Resolve]]'),
+			get_slot(resolvingFunctions, '[[Reject]]'),
+		]);
+	} catch (thenCallResultE) {
+		Call(get_slot(resolvingFunctions, '[[Reject]]'), undefined, [thenCallResultE]);
+	}
+}
+
+module.exports = class Promise {
+	constructor(executor) {
+		if (IsCallable(executor) === false) {
+			throw new TypeError('executor must be callable');
+		}
+
+		// Cheating a bit on NewTarget stuff here.
+
+		const promise = this;
+		make_slots(promise, [
+			'[[PromiseState]]',
+			'[[PromiseConstructor]]',
+			'[[PromiseResult]]',
+			'[[PromiseFulfillReactions]]',
+			'[[PromiseRejectReactions]]',
+			'[[PromiseIsHandled]]',
+		]);
+
+		set_slot(promise, '[[PromiseConstructor]]', this.constructor);
+		set_slot(promise, '[[PromiseState]]', 'pending');
+		set_slot(promise, '[[PromiseFulfillReactions]]', []);
+		set_slot(promise, '[[PromiseRejectReactions]]', []);
+		set_slot(promise, '[[PromiseIsHandled]]', false);
+		promise.id = global.id++;
+
+		const resolvingFunctions = CreateResolvingFunctions(promise);
+
+		try {
+			Call(executor, undefined, [
+				get_slot(resolvingFunctions, '[[Resolve]]'),
+				get_slot(resolvingFunctions, '[[Reject]]')
+			]);
+		} catch (completionE) {
+			Call(get_slot(resolvingFunctions, '[[Reject]]'), undefined, [completionE]);
+		}
+
+		return promise;
+	}
+
+	static all(iterable) {
+		let C = this;
+
+		if (Type(C) !== 'Object') {
+			throw new TypeError('Promise.all must be called on an object');
+		}
+
+		const S = Get(C, atAtSpecies);
+		if (S !== undefined && S !== null) {
+			C = S;
+		}
+
+		// The algorithm and indirection here, with PerformPromiseAll, manual iteration, and the closure-juggling, is just
+		// too convoluted compared to normal ES code, so let's skip it. The following should be equivalent; it maintains
+		// some of the formal translation in places, but skips on some of the structure.
+
+		return new C((resolve, reject) => {
+			const values = [];
+
+			let remainingElementsCount = 1;
+			let index = 0;
+
+			for (const nextValue of iterable) {
+				values.push(undefined);
+				const nextPromise = Invoke(C, 'resolve', [nextValue]);
+
+				let alreadyCalled = false;
+				const resolveElement = x => {
+					if (alreadyCalled === true) {
+						return undefined;
+					}
+					alreadyCalled = true;
+					values[index] = x;
+
+					remainingElementsCount = remainingElementsCount - 1;
+					if (remainingElementsCount === 0) {
+						resolve(values);
+					}
+				};
+
+				remainingElementsCount = remainingElementsCount + 1;
+
+				Invoke(nextPromise, 'then', [resolveElement, reject]);
+
+				index += 1;
+			}
+		});
+	}
+
+	static race(iterable) {
+		let C = this;
+
+		if (Type(C) !== 'Object') {
+			throw new TypeError('Promise.all must be called on an object');
+		}
+
+		const S = Get(C, atAtSpecies);
+		if (S !== undefined && S !== null) {
+			C = S;
+		}
+
+		// Similarly to for `Promise.all`, we avoid some of the indirection here.
+
+		return new C((resolve, reject) => {
+			for (const nextValue of iterable) {
+				const nextPromise = Invoke(C, 'resolve', [nextValue]);
+				Invoke(nextPromise, 'then', [resolve, reject]);
+			}
+		});
+	}
+
+	static reject(r) {
+		let C = this;
+
+		if (Type(C) !== 'Object') {
+			throw new TypeError('Promise.all must be called on an object');
+		}
+
+		const S = Get(C, atAtSpecies);
+		if (S !== undefined && S !== null) {
+			C = S;
+		}
+
+		const promiseCapability = NewPromiseCapability(C);
+		Call(get_slot(promiseCapability, '[[Reject]]'), undefined, [r]);
+		return get_slot(promiseCapability, '[[Promise]]');
+	}
+
+	static resolve(x) {
+		let C = this;
+
+		if (Type(C) !== 'Object') {
+			throw new TypeError('Promise.all must be called on an object');
+		}
+
+		if (IsPromise(x) === true) {
+			const xConstructor = Get(x, 'constructor');
+			if (SameValue(xConstructor, C) === true) {
+				return x;
+			}
+		}
+
+		const promiseCapability = NewPromiseCapability(C);
+		Call(get_slot(promiseCapability, '[[Resolve]]'), undefined, [x]);
+		return get_slot(promiseCapability, '[[Promise]]');
+	}
+
+	static get [atAtSpecies]() {
+		return this;
+	}
+
+	catch(onRejected) {
+		return Invoke(this, 'then', [undefined, onRejected]);
+	}
+
+	then(onFulfilled, onRejected) {
+		const promise = this;
+		if (IsPromise(this) === false) {
+			throw new TypeError('Promise.prototype.then only works on real promises');
+		}
+
+		const C = SpeciesConstructor(promise, Promise);
+		const resultCapability = NewPromiseCapability(C);
+		return PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability);
+	}
+}
+
+function createPromiseReactionRecord(capability, type, handler) {
+	const record = {};
+	make_slots(record, [
+		'[[Capability]]',
+		'[[Type]]',
+		'[[Handler]]',
+	]);
+	set_slot(record, '[[Capability]]', capability);
+	set_slot(record, '[[Type]]', type);
+	set_slot(record, '[[Handler]]', handler);
+	return record;
+}
+
+function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability) {
+	assert(IsPromise(promise) === true);
+	assert(IsPromiseCapabilityRecord(resultCapability) === true);
+
+	if (IsCallable(onFulfilled) === false) {
+		onFulfilled = undefined;
+	}
+
+	if (IsCallable(onRejected) === false) {
+		onRejected = undefined;
+	}
+
+	const fulfillReaction = createPromiseReactionRecord(resultCapability, 'Fulfill', onFulfilled);
+	const rejectReaction = createPromiseReactionRecord(resultCapability, 'Reject', onRejected);
+
+	const state = get_slot(promise, '[[PromiseState]]');
+
+	if (state === 'pending') {
+		get_slot(promise, '[[PromiseFulfillReactions]]').push(fulfillReaction);
+		get_slot(promise, '[[PromiseRejectReactions]]').push(rejectReaction);
+	} else if (state === 'fulfilled') {
+		const value = get_slot(promise, '[[PromiseResult]]');
+		EnqueueJob('PromiseJobs', PromiseReactionJob, [fulfillReaction, value]);
+	} else {
+		assert(state === 'rejected');
+		const reason = get_slot(promise, '[[PromiseResult]]');
+		if (get_slot(promise, '[[PromiseIsHandled]]') === false) {
+			HostPromiseRejectionTracker(promise, 'handle');
+		}
+		EnqueueJob('PromiseJobs', PromiseReactionJob, [rejectReaction, reason]);
+	}
+
+	set_slot(promise, '[[PromiseIsHandled]]', true);
+	return get_slot(resultCapability, '[[Promise]]');
+}

--- a/test/test.js
+++ b/test/test.js
@@ -17,3 +17,283 @@ describe('mocha promise sanity check', () => {
     return P.reject(someRejectionReason).catch(x => 'this should be resolved');
   });
 });
+
+describe('onFinally', () => {
+	describe('no callback', () => {
+		specify('from resolved', () => {
+			return adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally()
+				.then(function onFulfilled(x) {
+					assert.strictEqual(x, 3);
+				}, function onRejected() {
+					throw new Error('should not be called');
+				});
+		});
+
+		specify('from rejected', () => {
+			return adapter.rejected(someRejectionReason)
+				.catch((e) => {
+					assert.strictEqual(e, someRejectionReason);
+					throw e;
+				})
+				.finally()
+				.then(function onFulfilled() {
+					throw new Error('should not be called');
+				}, function onRejected(reason) {
+					assert.strictEqual(reason, someRejectionReason);
+				});
+		});
+	});
+
+	describe('throws an exception', () => {
+		specify('from resolved', () => {
+			return adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					throw someRejectionReason;
+				}).then(function onFulfilled() {
+					throw new Error('should not be called');
+				}, function onRejected(reason) {
+					assert.strictEqual(reason, someRejectionReason);
+				});
+		});
+
+		specify('from rejected', () => {
+			return adapter.rejected(anotherReason).finally(function onFinally() {
+				assert(arguments.length === 0);
+				throw someRejectionReason;
+			}).then(function onFulfilled() {
+				throw new Error('should not be called');
+			}, function onRejected(reason) {
+				assert.strictEqual(reason, someRejectionReason);
+			});
+		});
+	});
+
+	describe('returns a non-promise', () => {
+		specify('from resolved', () => {
+			return adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					return 4;
+				}).then(function onFulfilled(x) {
+					assert.strictEqual(x, 3);
+				}, function onRejected() {
+					throw new Error('should not be called');
+				});
+		});
+
+		specify('from rejected', () => {
+			return adapter.rejected(anotherReason)
+				.catch((e) => {
+					assert.strictEqual(e, anotherReason);
+					throw e;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					throw someRejectionReason;
+				}).then(function onFulfilled() {
+					throw new Error('should not be called');
+				}, function onRejected(e) {
+					assert.strictEqual(e, someRejectionReason);
+				});
+		});
+	});
+
+	describe('returns a pending-forever promise', () => {
+		specify('from resolved', (done) => {
+			adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					setTimeout(done, 0.1e3);
+					return new P(() => {}); // forever pending
+				}).then(function onFulfilled(x) {
+					throw new Error('should not be called');
+				}, function onRejected() {
+					throw new Error('should not be called');
+				});
+		});
+
+		specify('from rejected', (done) => {
+			adapter.rejected(someRejectionReason)
+				.catch((e) => {
+					assert.strictEqual(e, someRejectionReason);
+					throw e;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					setTimeout(done, 0.1e3);
+					return new P(() => {}); // forever pending
+				}).then(function onFulfilled(x) {
+					throw new Error('should not be called');
+				}, function onRejected() {
+					throw new Error('should not be called');
+				});
+		});
+	});
+
+	describe('returns an immediately-fulfilled promise', () => {
+		specify('from resolved', () => {
+			return adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					return adapter.resolved(4);
+				}).then(function onFulfilled(x) {
+					assert.strictEqual(x, 3);
+				}, function onRejected() {
+					throw new Error('should not be called');
+				});
+		});
+
+		specify('from rejected', () => {
+			return adapter.rejected(someRejectionReason)
+				.catch((e) => {
+					assert.strictEqual(e, someRejectionReason);
+					throw e;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					return adapter.resolved(4);
+				}).then(function onFulfilled() {
+					throw new Error('should not be called');
+				}, function onRejected(e) {
+					assert.strictEqual(e, someRejectionReason);
+				});
+		});
+	});
+
+	describe('returns an immediately-rejected promise', () => {
+		specify('from resolved ', () => {
+			return adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					return adapter.rejected(4);
+				}).then(function onFulfilled(x) {
+					throw new Error('should not be called');
+				}, function onRejected(e) {
+					assert.strictEqual(e, 4);
+				});
+		});
+
+		specify('from rejected', () => {
+      const newReason = {};
+			return adapter.rejected(someRejectionReason)
+				.catch((e) => {
+					assert.strictEqual(e, someRejectionReason);
+					throw e;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					return adapter.rejected(newReason);
+				}).then(function onFulfilled(x) {
+					throw new Error('should not be called');
+				}, function onRejected(e) {
+					assert.strictEqual(e, newReason);
+				});
+		});
+	});
+
+	describe('returns a fulfilled-after-a-second promise', () => {
+		specify('from resolved', (done) => {
+			adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					setTimeout(done, 1.5e3);
+					return new P((resolve) => {
+						setTimeout(() => resolve(4), 1e3);
+					});
+				}).then(function onFulfilled(x) {
+					assert.strictEqual(x, 3);
+				}, function onRejected() {
+					throw new Error('should not be called');
+				});
+		});
+
+		specify('from rejected', (done) => {
+			adapter.rejected(3)
+				.catch((e) => {
+					assert.strictEqual(e, 3);
+					throw e;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					setTimeout(done, 1.5e3);
+					return new P((resolve) => {
+						setTimeout(() => resolve(4), 1e3);
+					});
+				}).then(function onFulfilled() {
+					throw new Error('should not be called');
+				}, function onRejected(e) {
+					assert.strictEqual(e, 3);
+				});
+		});
+	});
+
+	describe('returns a rejected-after-a-second promise', () => {
+		specify('from resolved', (done) => {
+			adapter.resolved(3)
+				.then((x) => {
+					assert.strictEqual(x, 3);
+					return x;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					setTimeout(done, 1.5e3);
+					return new P((resolve, reject) => {
+						setTimeout(() => reject(4), 1e3);
+					});
+				}).then(function onFulfilled(x) {
+					assert.strictEqual(x, 3);
+				}, function onRejected() {
+					throw new Error('should not be called');
+				});
+		});
+
+		specify('from rejected', (done) => {
+			adapter.rejected(someRejectionReason)
+				.catch((e) => {
+					assert.strictEqual(e, someRejectionReason);
+					throw e;
+				})
+				.finally(function onFinally() {
+					assert(arguments.length === 0);
+					setTimeout(done, 1.5e3);
+					return new P((resolve, reject) => {
+						setTimeout(() => reject(anotherReason), 1e3);
+					});
+				}).then(function onFulfilled() {
+					throw new Error('should not be called');
+				}, function onRejected(e) {
+					assert.strictEqual(e, anotherReason);
+				});
+		});
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var assert = require('assert');
+
+var P = require('./promise');
+var adapter = require('./adapter');
+
+var someRejectionReason = { message: 'some rejection reason' };
+var anotherReason = { message: 'another rejection reason' };
+
+describe('mocha promise sanity check', () => {
+  it('passes with a resolved promise', () => {
+    return P.resolve(3);
+  });
+
+  it('passes with a rejected then resolved promise', () => {
+    return P.reject(someRejectionReason).catch(x => 'this should be resolved');
+  });
+});


### PR DESCRIPTION
@domenic 

The first commit matches the current spec, and passes all the A+ tests.

The second commit makes the required tweaks to the JS to pass the new "finally" tests.

The third commit updates the spec text to match the now-passing JS.

tl;dr: the approach of [[Type]] being "Finally" didn't work well after all, because `PromiseReactionJob` didn't know whether the promise was resolved or rejected. This approach uses the Fulfill/Reject reactions to convey that knowledge, building up callback functions in `PerformPromiseFinally` rather than deferring that logic til a later tick.

Check out the branch and run `npm test` to run both the A+ tests and the "finally" tests.
