### PR TITLE
Make the property non-enumerable in the polyfill

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -37,5 +37,5 @@ if (typeof Promise.prototype.finally !== 'function') {
 			return newPromise;
 		}
 	};
-	Promise.prototype.finally = shim.finally;
+	Object.defineProperty(Promise.prototype, 'finally', { configurable: true, writable: true, value: shim.finally });
 }

--- a/test/test.js
+++ b/test/test.js
@@ -296,4 +296,12 @@ describe('onFinally', () => {
 				});
 		});
 	});
+
+	specify('has the correct property descriptor', () => {
+		var descriptor = Object.getOwnPropertyDescriptor(P.prototype, 'finally');
+
+		assert.strictEqual(descriptor.writable, true);
+		assert.strictEqual(descriptor.configurable, true);
+		assert.strictEqual(descriptor.enumerable, false);
+	});
 });


### PR DESCRIPTION
Based on the current spec, `Promise.prototype.finally` is supposed to be non-enumerable. This updates the polyfill to match that behavior.