### PR TITLE
Fix broken spec urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ I’d briefly considered `always` as an alternative, since that wouldn’t imply
  - [jQuery jqXHR#always](http://api.jquery.com/jQuery.ajax/#jqXHR)
 
 ## Spec
-You can view the spec in [markdown format](spec.md) or rendered as [HTML](http://ljharb.github.io/proposal-promise-finally/).
+You can view the spec in [markdown format](spec.md) or rendered as [HTML](https://tc39.github.io/proposal-promise-finally/).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ljharb/proposal-promise-finally.git"
+		"url": "git+https://github.com/tc39/proposal-promise-finally.git"
 	},
 	"keywords": [
 		"promise",
@@ -29,9 +29,9 @@
 	"author": "Jordan Harband <ljharb@gmail.com>",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/ljharb/proposal-promise-finally/issues"
+		"url": "https://github.com/tc39/proposal-promise-finally/issues"
 	},
-	"homepage": "https://github.com/ljharb/proposal-promise-finally#readme",
+	"homepage": "https://github.com/tc39/proposal-promise-finally#readme",
 	"dependencies": {
 		"especially": "^2.0.1"
 	},


### PR DESCRIPTION
Two instances which still pointed at the ljharb url which, unfortunately, does not redirect.