### PR TITLE
Use SpeciesConstructor; invoke .then; refactor closures

### DIFF
--- a/index.html
+++ b/index.html
@@ -2197,8 +2197,7 @@
 							<emu-xref aoid="IsCallable" id="_ref_7"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
 							<emu-val>true</emu-val>.</li>
 						<li>Let <var>result</var> be ?
-							<emu-xref aoid="Call" id="_ref_8"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
-							<emu-val>undefined</emu-val>).</li>
+							<emu-xref aoid="Call" id="_ref_8"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>).</li>
 						<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
 						<li>Assert:
 							<emu-xref aoid="IsConstructor" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
@@ -2207,8 +2206,7 @@
 							<emu-xref aoid="PromiseResolve" id="_ref_10"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
 						<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
 						<li>Return ?
-							<emu-xref aoid="Invoke" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>valueThunk</var>,
-							<emu-val>undefined</emu-val> »).
+							<emu-xref aoid="Invoke" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>valueThunk</var> »).
 						</li>
 					</ol>
 				</emu-alg>
@@ -2225,8 +2223,7 @@
 							<emu-xref aoid="IsCallable" id="_ref_12"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
 							<emu-val>true</emu-val>.</li>
 						<li>Let <var>result</var> be ?
-							<emu-xref aoid="Call" id="_ref_13"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
-							<emu-val>undefined</emu-val>).</li>
+							<emu-xref aoid="Call" id="_ref_13"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>).</li>
 						<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
 						<li>Assert:
 							<emu-xref aoid="IsConstructor" id="_ref_14"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
@@ -2235,8 +2232,7 @@
 							<emu-xref aoid="PromiseResolve" id="_ref_15"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
 						<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
 						<li>Return ?
-							<emu-xref aoid="Invoke" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thrower</var>,
-							<emu-val>undefined</emu-val> »).
+							<emu-xref aoid="Invoke" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thrower</var> »).
 						</li>
 					</ol>
 				</emu-alg>

--- a/index.html
+++ b/index.html
@@ -29,13 +29,31 @@
 			"type": "clause",
 			"id": "sec-createthenfinally",
 			"aoid": "CreateThenFinally",
-			"title": "CreateThenFinally ( onFinally )",
-			"titleHTML": "CreateThenFinally ( <var>onFinally</var> )",
+			"title": "CreateThenFinally ( C, onFinally )",
+			"titleHTML": "CreateThenFinally ( <var>C</var>, <var>onFinally</var> )",
 			"number": "2",
 			"namespace": "<no location>",
 			"location": "",
-			"referencingIds": ["_ref_1", "_ref_9"],
-			"key": "CreateThenFinally ( onFinally )"
+			"referencingIds": ["_ref_4", "_ref_14"],
+			"key": "CreateThenFinally ( C, onFinally )"
+		}, {
+			"type": "op",
+			"aoid": "ThenFinallyFunction",
+			"refId": "sec-thenfinallyfunction",
+			"location": "",
+			"referencingIds": [],
+			"key": "ThenFinallyFunction"
+		}, {
+			"type": "clause",
+			"id": "sec-thenfinallyfunction",
+			"aoid": "ThenFinallyFunction",
+			"title": "ThenFinally Function",
+			"titleHTML": "ThenFinally Function",
+			"number": "3",
+			"namespace": "<no location>",
+			"location": "",
+			"referencingIds": ["_ref_0"],
+			"key": "ThenFinally Function"
 		}, {
 			"type": "op",
 			"aoid": "CreateCatchFinally",
@@ -47,20 +65,38 @@
 			"type": "clause",
 			"id": "sec-createcatchfinally",
 			"aoid": "CreateCatchFinally",
-			"title": "CreateCatchFinally ( onFinally )",
-			"titleHTML": "CreateCatchFinally ( <var>onFinally</var> )",
-			"number": "3",
+			"title": "CreateCatchFinally ( C, onFinally )",
+			"titleHTML": "CreateCatchFinally ( <var>C</var>, <var>onFinally</var> )",
+			"number": "4",
 			"namespace": "<no location>",
 			"location": "",
-			"referencingIds": ["_ref_2"],
-			"key": "CreateCatchFinally ( onFinally )"
+			"referencingIds": ["_ref_5"],
+			"key": "CreateCatchFinally ( C, onFinally )"
+		}, {
+			"type": "op",
+			"aoid": "CatchFinallyFunction",
+			"refId": "sec-catchfinallyfunction",
+			"location": "",
+			"referencingIds": [],
+			"key": "CatchFinallyFunction"
+		}, {
+			"type": "clause",
+			"id": "sec-catchfinallyfunction",
+			"aoid": "CatchFinallyFunction",
+			"title": "CatchFinally Function",
+			"titleHTML": "CatchFinally Function",
+			"number": "5",
+			"namespace": "<no location>",
+			"location": "",
+			"referencingIds": ["_ref_1"],
+			"key": "CatchFinally Function"
 		}, {
 			"type": "clause",
 			"id": "sec-promise.resolve",
 			"aoid": null,
 			"title": "Promise.resolve ( x )",
 			"titleHTML": "Promise.resolve ( <var>x</var> )",
-			"number": "4",
+			"number": "6",
 			"namespace": "<no location>",
 			"location": "",
 			"referencingIds": [],
@@ -78,10 +114,10 @@
 			"aoid": "PromiseResolve",
 			"title": "PromiseResolve ( C, x )",
 			"titleHTML": "PromiseResolve ( <var>C</var>, <var>x</var> )",
-			"number": "5",
+			"number": "7",
 			"namespace": "<no location>",
 			"location": "",
-			"referencingIds": ["_ref_6", "_ref_12", "_ref_19"],
+			"referencingIds": ["_ref_12", "_ref_20", "_ref_26"],
 			"key": "PromiseResolve ( C, x )"
 		}, {
 			"type": "clause",
@@ -2130,10 +2166,12 @@
 		<div id="menu-toc">
 			<ol class="toc">
 				<li><span class="item-toggle-none"></span><a href="#sec-promise.prototype.finally" title="Promise.prototype.finally ( onFinally )"><span class="secnum">1</span> Promise.prototype.finally ( <var>onFinally</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-createthenfinally" title="CreateThenFinally ( onFinally )"><span class="secnum">2</span> CreateThenFinally ( <var>onFinally</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-createcatchfinally" title="CreateCatchFinally ( onFinally )"><span class="secnum">3</span> CreateCatchFinally ( <var>onFinally</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promise.resolve" title="Promise.resolve ( x )"><span class="secnum">4</span> Promise.resolve ( <var>x</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promise-resolve" title="PromiseResolve ( C, x )"><span class="secnum">5</span> PromiseResolve ( <var>C</var>, <var>x</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-createthenfinally" title="CreateThenFinally ( C, onFinally )"><span class="secnum">2</span> CreateThenFinally ( <var>C</var>, <var>onFinally</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-thenfinallyfunction" title="ThenFinally Function"><span class="secnum">3</span> ThenFinally Function</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-createcatchfinally" title="CreateCatchFinally ( C, onFinally )"><span class="secnum">4</span> CreateCatchFinally ( <var>C</var>, <var>onFinally</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-catchfinallyfunction" title="CatchFinally Function"><span class="secnum">5</span> CatchFinally Function</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-promise.resolve" title="Promise.resolve ( x )"><span class="secnum">6</span> Promise.resolve ( <var>x</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-promise-resolve" title="PromiseResolve ( C, x )"><span class="secnum">7</span> PromiseResolve ( <var>C</var>, <var>x</var> )</a></li>
 				<li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li>
 			</ol>
 		</div>
@@ -2150,76 +2188,117 @@
 					<li>Let <var>promise</var> be the
 						<emu-val>this</emu-val> value.</li>
 					<li>If
-						<emu-xref aoid="IsPromise" id="_ref_0"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>promise</var>) is
+						<emu-xref aoid="IsPromise" id="_ref_2"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>promise</var>) is
 						<emu-val>false</emu-val>, throw a
 						<emu-val>TypeError</emu-val> exception.</li>
+					<li>Let <var>C</var> be ?
+						<emu-xref aoid="SpeciesConstructor" id="_ref_3"><a href="https://tc39.github.io/ecma262/#sec-speciesconstructor">SpeciesConstructor</a></emu-xref>(<var>promise</var>,
+						<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
 					<li>Let <var>thenFinally</var> be !
-						<emu-xref aoid="CreateThenFinally" id="_ref_1"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref>(<var>onFinally</var>).</li>
+						<emu-xref aoid="CreateThenFinally" id="_ref_4"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref>(<var>C</var>, <var>onFinally</var>).</li>
 					<li>Let <var>catchFinally</var> be !
-						<emu-xref aoid="CreateCatchFinally" id="_ref_2"><a href="#sec-createcatchfinally">CreateCatchFinally</a></emu-xref>(<var>onFinally</var>).</li>
+						<emu-xref aoid="CreateCatchFinally" id="_ref_5"><a href="#sec-createcatchfinally">CreateCatchFinally</a></emu-xref>(<var>C</var>, <var>onFinally</var>).</li>
 					<li>Return ?
-						<emu-xref aoid="Invoke" id="_ref_3"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thenFinally</var>, <var>catchFinally</var> »).
+						<emu-xref aoid="Invoke" id="_ref_6"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thenFinally</var>, <var>catchFinally</var> »).
 					</li>
 				</ol>
 			</emu-alg>
 		</emu-clause>
 
 		<emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
-			<h1><span class="secnum">2</span>CreateThenFinally ( <var>onFinally</var> )</h1>
-			<p>The abstract operation CreateThenFinally takes an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
+			<h1><span class="secnum">2</span>CreateThenFinally ( <var>C</var>, <var>onFinally</var> )</h1>
+			<p>The abstract operation CreateThenFinally takes a Promise Constructor <var>C</var>, and an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
 			<emu-alg>
 				<ol>
+					<li>Assert:
+						<emu-xref aoid="IsConstructor" id="_ref_7"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
+						<emu-val>true</emu-val>.</li>
 					<li>If
-						<emu-xref aoid="IsCallable" id="_ref_4"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is not
+						<emu-xref aoid="IsCallable" id="_ref_8"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is not
 						<emu-val>true</emu-val>, return <var>onFinally</var>.</li>
-					<li>Return a function that takes one argument, <var>value</var>, and when invoked, performs the following steps:
-						<ol>
-							<li>Let <var>result</var> be ?
-								<emu-xref aoid="Call" id="_ref_5"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
-								<emu-val>undefined</emu-val>).</li>
-							<li>Let <var>promise</var> be !
-								<emu-xref aoid="PromiseResolve" id="_ref_6"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(
-								<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>).</li>
-							<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
-							<li>Let <var>promiseCapability</var> be !
-								<emu-xref aoid="NewPromiseCapability" id="_ref_7"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(
-								<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
-							<li>Return
-								<emu-xref aoid="PerformPromiseThen" id="_ref_8"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>, <var>valueThunk</var>,
-								<emu-val>undefined</emu-val>, <var>promiseCapability</var>).
-							</li>
-						</ol>
+					<li>Let <var>thenFinally</var> be a new built-in function object as defined in
+						<emu-xref href="#sec-thenfinallyfunction" id="_ref_0"><a href="#sec-thenfinallyfunction">ThenFinally Function</a></emu-xref>.</li>
+					<li>Set <var>thenFinally</var>.[[Constructor]] to <var>C</var>.</li>
+					<li>Set <var>thenFinally</var>.[[onFinally]] to <var>onFinally</var>.</li>
+					<li>Return <var>thenFinally</var>.
+					</li>
+				</ol>
+			</emu-alg>
+		</emu-clause>
+
+		<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
+			<h1><span class="secnum">3</span>ThenFinally Function</h1>
+			<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+			<p>When a ThenFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
+			<emu-alg>
+				<ol>
+					<li>Let <var>onFinally</var> be <var>F</var>.[[onFinally]].</li>
+					<li>Assert:
+						<emu-xref aoid="IsCallable" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
+						<emu-val>true</emu-val>.</li>
+					<li>Let <var>result</var> be ?
+						<emu-xref aoid="Call" id="_ref_10"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
+						<emu-val>undefined</emu-val>).</li>
+					<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
+					<li>Assert:
+						<emu-xref aoid="IsConstructor" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
+						<emu-val>true</emu-val>.</li>
+					<li>Let <var>promise</var> be !
+						<emu-xref aoid="PromiseResolve" id="_ref_12"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
+					<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
+					<li>Return ?
+						<emu-xref aoid="Invoke" id="_ref_13"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>valueThunk</var>,
+						<emu-val>undefined</emu-val> »).
 					</li>
 				</ol>
 			</emu-alg>
 		</emu-clause>
 
 		<emu-clause id="sec-createcatchfinally" aoid="CreateCatchFinally">
-			<h1><span class="secnum">3</span>CreateCatchFinally ( <var>onFinally</var> )</h1>
+			<h1><span class="secnum">4</span>CreateCatchFinally ( <var>C</var>, <var>onFinally</var> )</h1>
 			<p>The abstract operation
-				<emu-xref aoid="CreateThenFinally" id="_ref_9"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref> takes an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
+				<emu-xref aoid="CreateThenFinally" id="_ref_14"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref> takes an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
 			<emu-alg>
 				<ol>
+					<li>Assert:
+						<emu-xref aoid="IsConstructor" id="_ref_15"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
+						<emu-val>true</emu-val>.</li>
 					<li>If
-						<emu-xref aoid="IsCallable" id="_ref_10"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is not
+						<emu-xref aoid="IsCallable" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is not
 						<emu-val>true</emu-val>, return <var>onFinally</var>.</li>
-					<li>Return a function that takes one argument, <var>reason</var>, and when invoked, performs the following steps:
-						<ol>
-							<li>Let <var>result</var> be ?
-								<emu-xref aoid="Call" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
-								<emu-val>undefined</emu-val>).</li>
-							<li>Let <var>promise</var> be !
-								<emu-xref aoid="PromiseResolve" id="_ref_12"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(
-								<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>, <var>result</var>).</li>
-							<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
-							<li>Let <var>promiseCapability</var> be !
-								<emu-xref aoid="NewPromiseCapability" id="_ref_13"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(
-								<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
-							<li>Return
-								<emu-xref aoid="PerformPromiseThen" id="_ref_14"><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>promise</var>, <var>thrower</var>,
-								<emu-val>undefined</emu-val>, <var>promiseCapability</var>).
-							</li>
-						</ol>
+					<li>Let <var>catchFinally</var> be a new built-in function object as defined in
+						<emu-xref href="#sec-catchfinallyfunction" id="_ref_1"><a href="#sec-catchfinallyfunction">CatchFinally Function</a></emu-xref>.</li>
+					<li>Set <var>catchFinally</var>.[[Constructor]] to <var>C</var>.</li>
+					<li>Set <var>catchFinally</var>.[[onFinally]] to <var>onFinally</var>.</li>
+					<li>Return <var>catchFinally</var>.
+					</li>
+				</ol>
+			</emu-alg>
+		</emu-clause>
+
+		<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
+			<h1><span class="secnum">5</span>CatchFinally Function</h1>
+			<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+			<p>When a CatchFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
+			<emu-alg>
+				<ol>
+					<li>Let <var>onFinally</var> be <var>F</var>.[[onFinally]].</li>
+					<li>Assert:
+						<emu-xref aoid="IsCallable" id="_ref_17"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
+						<emu-val>true</emu-val>.</li>
+					<li>Let <var>result</var> be ?
+						<emu-xref aoid="Call" id="_ref_18"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
+						<emu-val>undefined</emu-val>).</li>
+					<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
+					<li>Assert:
+						<emu-xref aoid="IsConstructor" id="_ref_19"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
+						<emu-val>true</emu-val>.</li>
+					<li>Let <var>promise</var> be !
+						<emu-xref aoid="PromiseResolve" id="_ref_20"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
+					<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
+					<li>Return ?
+						<emu-xref aoid="Invoke" id="_ref_21"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thrower</var>,
+						<emu-val>undefined</emu-val> »).
 					</li>
 				</ol>
 			</emu-alg>
@@ -2227,28 +2306,28 @@
 
 		<!-- es6num="25.4.4.5" -->
 		<emu-clause id="sec-promise.resolve">
-			<h1><span class="secnum">4</span>Promise.resolve ( <var>x</var> )</h1>
+			<h1><span class="secnum">6</span>Promise.resolve ( <var>x</var> )</h1>
 			<p>The <code>resolve</code> function returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
 			<emu-alg>
 				<ol>
 					<li>Let <var>C</var> be the
 						<emu-val>this</emu-val> value.</li>
 					<li>If
-						<emu-xref aoid="Type" id="_ref_15"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is not Object, throw a
+						<emu-xref aoid="Type" id="_ref_22"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is not Object, throw a
 						<emu-val>TypeError</emu-val> exception.</li>
 					<li>If
-						<emu-xref aoid="IsPromise" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>x</var>) is
+						<emu-xref aoid="IsPromise" id="_ref_23"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>x</var>) is
 						<emu-val>true</emu-val>, then
 						<ol>
 							<li>Let <var>xConstructor</var> be ?
-								<emu-xref aoid="Get" id="_ref_17"><a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>x</var>, <code>"constructor"</code>).</li>
+								<emu-xref aoid="Get" id="_ref_24"><a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>x</var>, <code>"constructor"</code>).</li>
 							<li>If
-								<emu-xref aoid="SameValue" id="_ref_18"><a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>xConstructor</var>, <var>C</var>) is
+								<emu-xref aoid="SameValue" id="_ref_25"><a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>xConstructor</var>, <var>C</var>) is
 								<emu-val>true</emu-val>, return <var>x</var>.</li>
 						</ol>
 					</li>
 					<li>Return ?
-						<emu-xref aoid="PromiseResolve" id="_ref_19"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>x</var>).
+						<emu-xref aoid="PromiseResolve" id="_ref_26"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>x</var>).
 					</li>
 				</ol>
 			</emu-alg>
@@ -2261,16 +2340,16 @@
 		</emu-clause>
 
 		<emu-clause id="sec-promise-resolve" aoid="PromiseResolve">
-			<h1><span class="secnum">5</span>PromiseResolve ( <var>C</var>, <var>x</var> )</h1>
+			<h1><span class="secnum">7</span>PromiseResolve ( <var>C</var>, <var>x</var> )</h1>
 			<p>The abstract operation PromiseResolve, given a constructor and a value, returns a new promise resolved with that value.</p>
 			<emu-alg>
 				<ol>
 					<li>Assert:
-						<emu-xref aoid="Type" id="_ref_20"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is Object.</li>
+						<emu-xref aoid="Type" id="_ref_27"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is Object.</li>
 					<li>Let <var>promiseCapability</var> be ?
-						<emu-xref aoid="NewPromiseCapability" id="_ref_21"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<var>C</var>).</li>
+						<emu-xref aoid="NewPromiseCapability" id="_ref_28"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<var>C</var>).</li>
 					<li>Perform ?
-						<emu-xref aoid="Call" id="_ref_22"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]],
+						<emu-xref aoid="Call" id="_ref_29"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]],
 						<emu-val>undefined</emu-val>, « <var>x</var> »).</li>
 					<li>Return <var>promiseCapability</var>.[[Promise]].
 					</li>

--- a/index.html
+++ b/index.html
@@ -2202,7 +2202,7 @@
 						<li>Assert:
 							<emu-xref aoid="IsConstructor" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
 							<emu-val>true</emu-val>.</li>
-						<li>Let <var>promise</var> be !
+						<li>Let <var>promise</var> be ?
 							<emu-xref aoid="PromiseResolve" id="_ref_10"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
 						<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
 						<li>Return ?
@@ -2228,7 +2228,7 @@
 						<li>Assert:
 							<emu-xref aoid="IsConstructor" id="_ref_14"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
 							<emu-val>true</emu-val>.</li>
-						<li>Let <var>promise</var> be !
+						<li>Let <var>promise</var> be ?
 							<emu-xref aoid="PromiseResolve" id="_ref_15"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
 						<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
 						<li>Return ?

--- a/index.html
+++ b/index.html
@@ -2207,7 +2207,7 @@
 
 		<emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
 			<h1><span class="secnum">2</span>CreateThenFinally ( <var>C</var>, <var>onFinally</var> )</h1>
-			<p>The abstract operation CreateThenFinally takes a Promise Constructor <var>C</var>, and an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
+			<p>The abstract operation CreateThenFinally takes a <code>Promise</code>-like constructor function <var>C</var>, and an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
 			<emu-alg>
 				<ol>
 					<li>Assert:
@@ -2228,7 +2228,7 @@
 
 		<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
 			<h1><span class="secnum">3</span>ThenFinally Function</h1>
-			<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+			<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a <code>Promise</code>-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 			<p>When a ThenFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
 			<emu-alg>
 				<ol>
@@ -2278,7 +2278,7 @@
 
 		<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
 			<h1><span class="secnum">5</span>CatchFinally Function</h1>
-			<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+			<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a <code>Promise</code>-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 			<p>When a CatchFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
 			<emu-alg>
 				<ol>

--- a/index.html
+++ b/index.html
@@ -8,35 +8,6 @@
 	<title>Promise.prototype.finally</title>
 	<script type="application/json" id="menu-search-biblio">
 		[{
-			"type": "clause",
-			"id": "sec-promise.prototype.finally",
-			"aoid": null,
-			"title": "Promise.prototype.finally ( onFinally )",
-			"titleHTML": "Promise.prototype.finally ( <var>onFinally</var> )",
-			"number": "1",
-			"namespace": "<no location>",
-			"location": "",
-			"referencingIds": [],
-			"key": "Promise.prototype.finally ( onFinally )"
-		}, {
-			"type": "op",
-			"aoid": "CreateThenFinally",
-			"refId": "sec-createthenfinally",
-			"location": "",
-			"referencingIds": [],
-			"key": "CreateThenFinally"
-		}, {
-			"type": "clause",
-			"id": "sec-createthenfinally",
-			"aoid": "CreateThenFinally",
-			"title": "CreateThenFinally ( C, onFinally )",
-			"titleHTML": "CreateThenFinally ( <var>C</var>, <var>onFinally</var> )",
-			"number": "2",
-			"namespace": "<no location>",
-			"location": "",
-			"referencingIds": ["_ref_4", "_ref_14"],
-			"key": "CreateThenFinally ( C, onFinally )"
-		}, {
 			"type": "op",
 			"aoid": "ThenFinallyFunction",
 			"refId": "sec-thenfinallyfunction",
@@ -49,29 +20,11 @@
 			"aoid": "ThenFinallyFunction",
 			"title": "ThenFinally Function",
 			"titleHTML": "ThenFinally Function",
-			"number": "3",
+			"number": "1.1",
 			"namespace": "<no location>",
 			"location": "",
 			"referencingIds": ["_ref_0"],
 			"key": "ThenFinally Function"
-		}, {
-			"type": "op",
-			"aoid": "CreateCatchFinally",
-			"refId": "sec-createcatchfinally",
-			"location": "",
-			"referencingIds": [],
-			"key": "CreateCatchFinally"
-		}, {
-			"type": "clause",
-			"id": "sec-createcatchfinally",
-			"aoid": "CreateCatchFinally",
-			"title": "CreateCatchFinally ( C, onFinally )",
-			"titleHTML": "CreateCatchFinally ( <var>C</var>, <var>onFinally</var> )",
-			"number": "4",
-			"namespace": "<no location>",
-			"location": "",
-			"referencingIds": ["_ref_5"],
-			"key": "CreateCatchFinally ( C, onFinally )"
 		}, {
 			"type": "op",
 			"aoid": "CatchFinallyFunction",
@@ -85,18 +38,29 @@
 			"aoid": "CatchFinallyFunction",
 			"title": "CatchFinally Function",
 			"titleHTML": "CatchFinally Function",
-			"number": "5",
+			"number": "1.2",
 			"namespace": "<no location>",
 			"location": "",
 			"referencingIds": ["_ref_1"],
 			"key": "CatchFinally Function"
 		}, {
 			"type": "clause",
+			"id": "sec-promise.prototype.finally",
+			"aoid": null,
+			"title": "Promise.prototype.finally ( onFinally )",
+			"titleHTML": "Promise.prototype.finally ( <var>onFinally</var> )",
+			"number": "1",
+			"namespace": "<no location>",
+			"location": "",
+			"referencingIds": [],
+			"key": "Promise.prototype.finally ( onFinally )"
+		}, {
+			"type": "clause",
 			"id": "sec-promise.resolve",
 			"aoid": null,
 			"title": "Promise.resolve ( x )",
 			"titleHTML": "Promise.resolve ( <var>x</var> )",
-			"number": "6",
+			"number": "2",
 			"namespace": "<no location>",
 			"location": "",
 			"referencingIds": [],
@@ -114,10 +78,10 @@
 			"aoid": "PromiseResolve",
 			"title": "PromiseResolve ( C, x )",
 			"titleHTML": "PromiseResolve ( <var>C</var>, <var>x</var> )",
-			"number": "7",
+			"number": "3",
 			"namespace": "<no location>",
 			"location": "",
-			"referencingIds": ["_ref_12", "_ref_20", "_ref_26"],
+			"referencingIds": ["_ref_10", "_ref_15", "_ref_21"],
 			"key": "PromiseResolve ( C, x )"
 		}, {
 			"type": "clause",
@@ -2165,19 +2129,20 @@
 		<div class="menu-pane-header">Table of Contents</div>
 		<div id="menu-toc">
 			<ol class="toc">
-				<li><span class="item-toggle-none"></span><a href="#sec-promise.prototype.finally" title="Promise.prototype.finally ( onFinally )"><span class="secnum">1</span> Promise.prototype.finally ( <var>onFinally</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-createthenfinally" title="CreateThenFinally ( C, onFinally )"><span class="secnum">2</span> CreateThenFinally ( <var>C</var>, <var>onFinally</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-thenfinallyfunction" title="ThenFinally Function"><span class="secnum">3</span> ThenFinally Function</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-createcatchfinally" title="CreateCatchFinally ( C, onFinally )"><span class="secnum">4</span> CreateCatchFinally ( <var>C</var>, <var>onFinally</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-catchfinallyfunction" title="CatchFinally Function"><span class="secnum">5</span> CatchFinally Function</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promise.resolve" title="Promise.resolve ( x )"><span class="secnum">6</span> Promise.resolve ( <var>x</var> )</a></li>
-				<li><span class="item-toggle-none"></span><a href="#sec-promise-resolve" title="PromiseResolve ( C, x )"><span class="secnum">7</span> PromiseResolve ( <var>C</var>, <var>x</var> )</a></li>
+				<li><span class="item-toggle">◢</span><a href="#sec-promise.prototype.finally" title="Promise.prototype.finally ( onFinally )"><span class="secnum">1</span> Promise.prototype.finally ( <var>onFinally</var> )</a>
+					<ol class="toc">
+						<li><span class="item-toggle-none"></span><a href="#sec-thenfinallyfunction" title="ThenFinally Function"><span class="secnum">1.1</span> ThenFinally Function</a></li>
+						<li><span class="item-toggle-none"></span><a href="#sec-catchfinallyfunction" title="CatchFinally Function"><span class="secnum">1.2</span> CatchFinally Function</a></li>
+					</ol>
+				</li>
+				<li><span class="item-toggle-none"></span><a href="#sec-promise.resolve" title="Promise.resolve ( x )"><span class="secnum">2</span> Promise.resolve ( <var>x</var> )</a></li>
+				<li><span class="item-toggle-none"></span><a href="#sec-promise-resolve" title="PromiseResolve ( C, x )"><span class="secnum">3</span> PromiseResolve ( <var>C</var>, <var>x</var> )</a></li>
 				<li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li>
 			</ol>
 		</div>
 	</div>
 	<div id="spec-container">
-		<h1 class="version first">Stage 2 Draft / June 20, 2017</h1>
+		<h1 class="version first">Stage 2 Draft / June 21, 2017</h1>
 		<h1 class="title">Promise.prototype.finally</h1>
 
 		<emu-clause id="sec-promise.prototype.finally">
@@ -2194,140 +2159,114 @@
 					<li>Let <var>C</var> be ?
 						<emu-xref aoid="SpeciesConstructor" id="_ref_3"><a href="https://tc39.github.io/ecma262/#sec-speciesconstructor">SpeciesConstructor</a></emu-xref>(<var>promise</var>,
 						<emu-xref href="#sec-promise-constructor"><a href="https://tc39.github.io/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li>
-					<li>Let <var>thenFinally</var> be !
-						<emu-xref aoid="CreateThenFinally" id="_ref_4"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref>(<var>C</var>, <var>onFinally</var>).</li>
-					<li>Let <var>catchFinally</var> be !
-						<emu-xref aoid="CreateCatchFinally" id="_ref_5"><a href="#sec-createcatchfinally">CreateCatchFinally</a></emu-xref>(<var>C</var>, <var>onFinally</var>).</li>
+					<li>Assert:
+						<emu-xref aoid="IsConstructor" id="_ref_4"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
+						<emu-val>true</emu-val>.</li>
+					<li>If
+						<emu-xref aoid="IsCallable" id="_ref_5"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is not
+						<emu-val>true</emu-val>,
+						<ol>
+							<li>Let <var>thenFinally</var> be <var>onFinally</var>.</li>
+							<li>Let <var>catchFinally</var> be <var>onFinally</var>.</li>
+						</ol>
+					</li>
+					<li>Else,
+						<ol>
+							<li>Let <var>thenFinally</var> be a new built-in function object as defined in
+								<emu-xref href="#sec-thenfinallyfunction" id="_ref_0"><a href="#sec-thenfinallyfunction">ThenFinally Function</a></emu-xref>.</li>
+							<li>Let <var>catchFinally</var> be a new built-in function object as defined in
+								<emu-xref href="#sec-catchfinallyfunction" id="_ref_1"><a href="#sec-catchfinallyfunction">CatchFinally Function</a></emu-xref>.</li>
+							<li>Set <var>thenFinally</var> and <var>catchFinally</var>'s [[Constructor]] internal slots to <var>C</var>.</li>
+							<li>Set <var>thenFinally</var> and <var>catchFinally</var>'s [[OnFinally]] internal slots to <var>onFinally</var>.</li>
+						</ol>
+					</li>
 					<li>Return ?
 						<emu-xref aoid="Invoke" id="_ref_6"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thenFinally</var>, <var>catchFinally</var> »).
 					</li>
 				</ol>
 			</emu-alg>
-		</emu-clause>
 
-		<emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
-			<h1><span class="secnum">2</span>CreateThenFinally ( <var>C</var>, <var>onFinally</var> )</h1>
-			<p>The abstract operation CreateThenFinally takes a <code>Promise</code>-like constructor function <var>C</var>, and an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
-			<emu-alg>
-				<ol>
-					<li>Assert:
-						<emu-xref aoid="IsConstructor" id="_ref_7"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
-						<emu-val>true</emu-val>.</li>
-					<li>If
-						<emu-xref aoid="IsCallable" id="_ref_8"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is not
-						<emu-val>true</emu-val>, return <var>onFinally</var>.</li>
-					<li>Let <var>thenFinally</var> be a new built-in function object as defined in
-						<emu-xref href="#sec-thenfinallyfunction" id="_ref_0"><a href="#sec-thenfinallyfunction">ThenFinally Function</a></emu-xref>.</li>
-					<li>Set <var>thenFinally</var>.[[Constructor]] to <var>C</var>.</li>
-					<li>Set <var>thenFinally</var>.[[OnFinally]] to <var>onFinally</var>.</li>
-					<li>Return <var>thenFinally</var>.
-					</li>
-				</ol>
-			</emu-alg>
-		</emu-clause>
+			<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
+				<h1><span class="secnum">1.1</span>ThenFinally Function</h1>
+				<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a <code>Promise</code>-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+				<p>When a ThenFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
+				<emu-alg>
+					<ol>
+						<li>Let <var>onFinally</var> be <var>F</var>.[[OnFinally]].</li>
+						<li>Assert:
+							<emu-xref aoid="IsCallable" id="_ref_7"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
+							<emu-val>true</emu-val>.</li>
+						<li>Let <var>result</var> be ?
+							<emu-xref aoid="Call" id="_ref_8"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
+							<emu-val>undefined</emu-val>).</li>
+						<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
+						<li>Assert:
+							<emu-xref aoid="IsConstructor" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
+							<emu-val>true</emu-val>.</li>
+						<li>Let <var>promise</var> be !
+							<emu-xref aoid="PromiseResolve" id="_ref_10"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
+						<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
+						<li>Return ?
+							<emu-xref aoid="Invoke" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>valueThunk</var>,
+							<emu-val>undefined</emu-val> »).
+						</li>
+					</ol>
+				</emu-alg>
+			</emu-clause>
 
-		<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
-			<h1><span class="secnum">3</span>ThenFinally Function</h1>
-			<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a <code>Promise</code>-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-			<p>When a ThenFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
-			<emu-alg>
-				<ol>
-					<li>Let <var>onFinally</var> be <var>F</var>.[[OnFinally]].</li>
-					<li>Assert:
-						<emu-xref aoid="IsCallable" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
-						<emu-val>true</emu-val>.</li>
-					<li>Let <var>result</var> be ?
-						<emu-xref aoid="Call" id="_ref_10"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
-						<emu-val>undefined</emu-val>).</li>
-					<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
-					<li>Assert:
-						<emu-xref aoid="IsConstructor" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
-						<emu-val>true</emu-val>.</li>
-					<li>Let <var>promise</var> be !
-						<emu-xref aoid="PromiseResolve" id="_ref_12"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
-					<li>Let <var>valueThunk</var> be equivalent to a function that returns <var>value</var>.</li>
-					<li>Return ?
-						<emu-xref aoid="Invoke" id="_ref_13"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>valueThunk</var>,
-						<emu-val>undefined</emu-val> »).
-					</li>
-				</ol>
-			</emu-alg>
-		</emu-clause>
-
-		<emu-clause id="sec-createcatchfinally" aoid="CreateCatchFinally">
-			<h1><span class="secnum">4</span>CreateCatchFinally ( <var>C</var>, <var>onFinally</var> )</h1>
-			<p>The abstract operation
-				<emu-xref aoid="CreateThenFinally" id="_ref_14"><a href="#sec-createthenfinally">CreateThenFinally</a></emu-xref> takes an <var>onFinally</var> function, and returns a callback function for use in Promise.prototype.finally.</p>
-			<emu-alg>
-				<ol>
-					<li>Assert:
-						<emu-xref aoid="IsConstructor" id="_ref_15"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
-						<emu-val>true</emu-val>.</li>
-					<li>If
-						<emu-xref aoid="IsCallable" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is not
-						<emu-val>true</emu-val>, return <var>onFinally</var>.</li>
-					<li>Let <var>catchFinally</var> be a new built-in function object as defined in
-						<emu-xref href="#sec-catchfinallyfunction" id="_ref_1"><a href="#sec-catchfinallyfunction">CatchFinally Function</a></emu-xref>.</li>
-					<li>Set <var>catchFinally</var>.[[Constructor]] to <var>C</var>.</li>
-					<li>Set <var>catchFinally</var>.[[OnFinally]] to <var>onFinally</var>.</li>
-					<li>Return <var>catchFinally</var>.
-					</li>
-				</ol>
-			</emu-alg>
-		</emu-clause>
-
-		<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
-			<h1><span class="secnum">5</span>CatchFinally Function</h1>
-			<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a <code>Promise</code>-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-			<p>When a CatchFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
-			<emu-alg>
-				<ol>
-					<li>Let <var>onFinally</var> be <var>F</var>.[[OnFinally]].</li>
-					<li>Assert:
-						<emu-xref aoid="IsCallable" id="_ref_17"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
-						<emu-val>true</emu-val>.</li>
-					<li>Let <var>result</var> be ?
-						<emu-xref aoid="Call" id="_ref_18"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
-						<emu-val>undefined</emu-val>).</li>
-					<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
-					<li>Assert:
-						<emu-xref aoid="IsConstructor" id="_ref_19"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
-						<emu-val>true</emu-val>.</li>
-					<li>Let <var>promise</var> be !
-						<emu-xref aoid="PromiseResolve" id="_ref_20"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
-					<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
-					<li>Return ?
-						<emu-xref aoid="Invoke" id="_ref_21"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thrower</var>,
-						<emu-val>undefined</emu-val> »).
-					</li>
-				</ol>
-			</emu-alg>
+			<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
+				<h1><span class="secnum">1.2</span>CatchFinally Function</h1>
+				<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a <code>Promise</code>-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+				<p>When a CatchFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
+				<emu-alg>
+					<ol>
+						<li>Let <var>onFinally</var> be <var>F</var>.[[OnFinally]].</li>
+						<li>Assert:
+							<emu-xref aoid="IsCallable" id="_ref_12"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
+							<emu-val>true</emu-val>.</li>
+						<li>Let <var>result</var> be ?
+							<emu-xref aoid="Call" id="_ref_13"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>onFinally</var>,
+							<emu-val>undefined</emu-val>).</li>
+						<li>Let <var>C</var> be <var>F</var>.[[Constructor]].</li>
+						<li>Assert:
+							<emu-xref aoid="IsConstructor" id="_ref_14"><a href="https://tc39.github.io/ecma262/#sec-isconstructor">IsConstructor</a></emu-xref>(<var>C</var>) is
+							<emu-val>true</emu-val>.</li>
+						<li>Let <var>promise</var> be !
+							<emu-xref aoid="PromiseResolve" id="_ref_15"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>result</var>).</li>
+						<li>Let <var>thrower</var> be equivalent to a function that throws <var>reason</var>.</li>
+						<li>Return ?
+							<emu-xref aoid="Invoke" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-invoke">Invoke</a></emu-xref>(<var>promise</var>, <code>"then"</code>, « <var>thrower</var>,
+							<emu-val>undefined</emu-val> »).
+						</li>
+					</ol>
+				</emu-alg>
+			</emu-clause>
 		</emu-clause>
 
 		<!-- es6num="25.4.4.5" -->
 		<emu-clause id="sec-promise.resolve">
-			<h1><span class="secnum">6</span>Promise.resolve ( <var>x</var> )</h1>
+			<h1><span class="secnum">2</span>Promise.resolve ( <var>x</var> )</h1>
 			<p>The <code>resolve</code> function returns either a new promise resolved with the passed argument, or the argument itself if the argument is a promise produced by this constructor.</p>
 			<emu-alg>
 				<ol>
 					<li>Let <var>C</var> be the
 						<emu-val>this</emu-val> value.</li>
 					<li>If
-						<emu-xref aoid="Type" id="_ref_22"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is not Object, throw a
+						<emu-xref aoid="Type" id="_ref_17"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is not Object, throw a
 						<emu-val>TypeError</emu-val> exception.</li>
 					<li>If
-						<emu-xref aoid="IsPromise" id="_ref_23"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>x</var>) is
+						<emu-xref aoid="IsPromise" id="_ref_18"><a href="https://tc39.github.io/ecma262/#sec-ispromise">IsPromise</a></emu-xref>(<var>x</var>) is
 						<emu-val>true</emu-val>, then
 						<ol>
 							<li>Let <var>xConstructor</var> be ?
-								<emu-xref aoid="Get" id="_ref_24"><a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>x</var>, <code>"constructor"</code>).</li>
+								<emu-xref aoid="Get" id="_ref_19"><a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a></emu-xref>(<var>x</var>, <code>"constructor"</code>).</li>
 							<li>If
-								<emu-xref aoid="SameValue" id="_ref_25"><a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>xConstructor</var>, <var>C</var>) is
+								<emu-xref aoid="SameValue" id="_ref_20"><a href="https://tc39.github.io/ecma262/#sec-samevalue">SameValue</a></emu-xref>(<var>xConstructor</var>, <var>C</var>) is
 								<emu-val>true</emu-val>, return <var>x</var>.</li>
 						</ol>
 					</li>
 					<li>Return ?
-						<emu-xref aoid="PromiseResolve" id="_ref_26"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>x</var>).
+						<emu-xref aoid="PromiseResolve" id="_ref_21"><a href="#sec-promise-resolve">PromiseResolve</a></emu-xref>(<var>C</var>, <var>x</var>).
 					</li>
 				</ol>
 			</emu-alg>
@@ -2340,16 +2279,16 @@
 		</emu-clause>
 
 		<emu-clause id="sec-promise-resolve" aoid="PromiseResolve">
-			<h1><span class="secnum">7</span>PromiseResolve ( <var>C</var>, <var>x</var> )</h1>
+			<h1><span class="secnum">3</span>PromiseResolve ( <var>C</var>, <var>x</var> )</h1>
 			<p>The abstract operation PromiseResolve, given a constructor and a value, returns a new promise resolved with that value.</p>
 			<emu-alg>
 				<ol>
 					<li>Assert:
-						<emu-xref aoid="Type" id="_ref_27"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is Object.</li>
+						<emu-xref aoid="Type" id="_ref_22"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>C</var>) is Object.</li>
 					<li>Let <var>promiseCapability</var> be ?
-						<emu-xref aoid="NewPromiseCapability" id="_ref_28"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<var>C</var>).</li>
+						<emu-xref aoid="NewPromiseCapability" id="_ref_23"><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<var>C</var>).</li>
 					<li>Perform ?
-						<emu-xref aoid="Call" id="_ref_29"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]],
+						<emu-xref aoid="Call" id="_ref_24"><a href="https://tc39.github.io/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]],
 						<emu-val>undefined</emu-val>, « <var>x</var> »).</li>
 					<li>Return <var>promiseCapability</var>.[[Promise]].
 					</li>

--- a/index.html
+++ b/index.html
@@ -2219,7 +2219,7 @@
 					<li>Let <var>thenFinally</var> be a new built-in function object as defined in
 						<emu-xref href="#sec-thenfinallyfunction" id="_ref_0"><a href="#sec-thenfinallyfunction">ThenFinally Function</a></emu-xref>.</li>
 					<li>Set <var>thenFinally</var>.[[Constructor]] to <var>C</var>.</li>
-					<li>Set <var>thenFinally</var>.[[onFinally]] to <var>onFinally</var>.</li>
+					<li>Set <var>thenFinally</var>.[[OnFinally]] to <var>onFinally</var>.</li>
 					<li>Return <var>thenFinally</var>.
 					</li>
 				</ol>
@@ -2228,11 +2228,11 @@
 
 		<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
 			<h1><span class="secnum">3</span>ThenFinally Function</h1>
-			<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+			<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 			<p>When a ThenFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
 			<emu-alg>
 				<ol>
-					<li>Let <var>onFinally</var> be <var>F</var>.[[onFinally]].</li>
+					<li>Let <var>onFinally</var> be <var>F</var>.[[OnFinally]].</li>
 					<li>Assert:
 						<emu-xref aoid="IsCallable" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
 						<emu-val>true</emu-val>.</li>
@@ -2269,7 +2269,7 @@
 					<li>Let <var>catchFinally</var> be a new built-in function object as defined in
 						<emu-xref href="#sec-catchfinallyfunction" id="_ref_1"><a href="#sec-catchfinallyfunction">CatchFinally Function</a></emu-xref>.</li>
 					<li>Set <var>catchFinally</var>.[[Constructor]] to <var>C</var>.</li>
-					<li>Set <var>catchFinally</var>.[[onFinally]] to <var>onFinally</var>.</li>
+					<li>Set <var>catchFinally</var>.[[OnFinally]] to <var>onFinally</var>.</li>
 					<li>Return <var>catchFinally</var>.
 					</li>
 				</ol>
@@ -2278,11 +2278,11 @@
 
 		<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
 			<h1><span class="secnum">5</span>CatchFinally Function</h1>
-			<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+			<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 			<p>When a CatchFinally function <var>F</var> is called with argument <var>value</var>, the following steps are taken:</p>
 			<emu-alg>
 				<ol>
-					<li>Let <var>onFinally</var> be <var>F</var>.[[onFinally]].</li>
+					<li>Let <var>onFinally</var> be <var>F</var>.[[OnFinally]].</li>
 					<li>Assert:
 						<emu-xref aoid="IsCallable" id="_ref_17"><a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a></emu-xref>(<var>onFinally</var>) is
 						<emu-val>true</emu-val>.</li>

--- a/spec.emu
+++ b/spec.emu
@@ -35,12 +35,12 @@ contributors: Jordan Harband
 		<emu-alg>
 			1. Let _onFinally_ be _F_.[[OnFinally]].
 			1. Assert: IsCallable(_onFinally_) is *true*.
-			1. Let _result_ be ? Call(_onFinally_, *undefined*).
+			1. Let _result_ be ? Call(_onFinally_).
 			1. Let _C_ be _F_.[[Constructor]].
 			1. Assert: IsConstructor(_C_) is *true*.
 			1. Let _promise_ be ! PromiseResolve(_C_, _result_).
 			1. Let _valueThunk_ be equivalent to a function that returns _value_.
-			1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_, *undefined* &raquo;).
+			1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
 		</emu-alg>
 	</emu-clause>
 
@@ -51,12 +51,12 @@ contributors: Jordan Harband
 		<emu-alg>
 			1. Let _onFinally_ be _F_.[[OnFinally]].
 			1. Assert: IsCallable(_onFinally_) is *true*.
-			1. Let _result_ be ? Call(_onFinally_, *undefined*).
+			1. Let _result_ be ? Call(_onFinally_).
 			1. Let _C_ be _F_.[[Constructor]].
 			1. Assert: IsConstructor(_C_) is *true*.
 			1. Let _promise_ be ! PromiseResolve(_C_, _result_).
 			1. Let _thrower_ be equivalent to a function that throws _reason_.
-			1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_, *undefined* &raquo;).
+			1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_ &raquo;).
 		</emu-alg>
 	</emu-clause>
 </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -24,7 +24,7 @@ contributors: Jordan Harband
 
 <emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
 	<h1>CreateThenFinally ( _C_, _onFinally_ )</h1>
-	<p>The abstract operation CreateThenFinally takes a Promise Constructor _C_, and an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.</p>
+	<p>The abstract operation CreateThenFinally takes a `Promise`-like constructor function _C_, and an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.</p>
 	<emu-alg>
 		1. Assert: IsConstructor(_C_) is *true*.
 		1. If IsCallable(_onFinally_) is not *true*, return _onFinally_.
@@ -37,7 +37,7 @@ contributors: Jordan Harband
 
 <emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
 	<h1>ThenFinally Function</h1>
-	<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+	<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 	<p>When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:</p>
 	<emu-alg>
 		1. Let _onFinally_ be _F_.[[OnFinally]].
@@ -66,7 +66,7 @@ contributors: Jordan Harband
 
 <emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
 	<h1>CatchFinally Function</h1>
-	<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+	<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 	<p>When a CatchFinally function _F_ is called with argument _value_, the following steps are taken:</p>
 	<emu-alg>
 		1. Let _onFinally_ be _F_.[[OnFinally]].

--- a/spec.emu
+++ b/spec.emu
@@ -16,68 +16,49 @@ contributors: Jordan Harband
 		1. Let _promise_ be the *this* value.
 		1. If IsPromise(_promise_) is *false*, throw a *TypeError* exception.
 		1. Let _C_ be ? SpeciesConstructor(_promise_, %Promise%).
-		1. Let _thenFinally_ be ! CreateThenFinally(_C_, _onFinally_).
-		1. Let _catchFinally_ be ! CreateCatchFinally(_C_, _onFinally_).
+		1. Assert: IsConstructor(_C_) is *true*.
+		1. If IsCallable(_onFinally_) is not *true*,
+			1. Let _thenFinally_ be _onFinally_.
+			1. Let _catchFinally_ be _onFinally_.
+		1. Else,
+			1. Let _thenFinally_ be a new built-in function object as defined in <emu-xref href="#sec-thenfinallyfunction">ThenFinally Function</emu-xref>.
+			1. Let _catchFinally_ be a new built-in function object as defined in <emu-xref href="#sec-catchfinallyfunction">CatchFinally Function</emu-xref>.
+			1. Set _thenFinally_ and _catchFinally_'s [[Constructor]] internal slots to _C_.
+			1. Set _thenFinally_ and _catchFinally_'s [[OnFinally]] internal slots to _onFinally_.
 		1. Return ? Invoke(_promise_, `"then"`, &laquo; _thenFinally_, _catchFinally_ &raquo;).
 	</emu-alg>
-</emu-clause>
 
-<emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
-	<h1>CreateThenFinally ( _C_, _onFinally_ )</h1>
-	<p>The abstract operation CreateThenFinally takes a `Promise`-like constructor function _C_, and an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.</p>
-	<emu-alg>
-		1. Assert: IsConstructor(_C_) is *true*.
-		1. If IsCallable(_onFinally_) is not *true*, return _onFinally_.
-		1. Let _thenFinally_ be a new built-in function object as defined in <emu-xref href="#sec-thenfinallyfunction">ThenFinally Function</emu-xref>.
-		1. Set _thenFinally_.[[Constructor]] to _C_.
-		1. Set _thenFinally_.[[OnFinally]] to _onFinally_.
-		1. Return _thenFinally_.
-	</emu-alg>
-</emu-clause>
+	<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
+		<h1>ThenFinally Function</h1>
+		<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+		<p>When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:</p>
+		<emu-alg>
+			1. Let _onFinally_ be _F_.[[OnFinally]].
+			1. Assert: IsCallable(_onFinally_) is *true*.
+			1. Let _result_ be ? Call(_onFinally_, *undefined*).
+			1. Let _C_ be _F_.[[Constructor]].
+			1. Assert: IsConstructor(_C_) is *true*.
+			1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+			1. Let _valueThunk_ be equivalent to a function that returns _value_.
+			1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_, *undefined* &raquo;).
+		</emu-alg>
+	</emu-clause>
 
-<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
-	<h1>ThenFinally Function</h1>
-	<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-	<p>When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:</p>
-	<emu-alg>
-		1. Let _onFinally_ be _F_.[[OnFinally]].
-		1. Assert: IsCallable(_onFinally_) is *true*.
-		1. Let _result_ be ? Call(_onFinally_, *undefined*).
-		1. Let _C_ be _F_.[[Constructor]].
-		1. Assert: IsConstructor(_C_) is *true*.
-		1. Let _promise_ be ! PromiseResolve(_C_, _result_).
-		1. Let _valueThunk_ be equivalent to a function that returns _value_.
-		1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_, *undefined* &raquo;).
-	</emu-alg>
-</emu-clause>
-
-<emu-clause id="sec-createcatchfinally" aoid="CreateCatchFinally">
-	<h1>CreateCatchFinally ( _C_, _onFinally_ )</h1>
-	<p>The abstract operation CreateThenFinally takes an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.</p>
-	<emu-alg>
-		1. Assert: IsConstructor(_C_) is *true*.
-		1. If IsCallable(_onFinally_) is not *true*, return _onFinally_.
-		1. Let _catchFinally_ be a new built-in function object as defined in <emu-xref href="#sec-catchfinallyfunction">CatchFinally Function</emu-xref>.
-		1. Set _catchFinally_.[[Constructor]] to _C_.
-		1. Set _catchFinally_.[[OnFinally]] to _onFinally_.
-		1. Return _catchFinally_.
-	</emu-alg>
-</emu-clause>
-
-<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
-	<h1>CatchFinally Function</h1>
-	<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
-	<p>When a CatchFinally function _F_ is called with argument _value_, the following steps are taken:</p>
-	<emu-alg>
-		1. Let _onFinally_ be _F_.[[OnFinally]].
-		1. Assert: IsCallable(_onFinally_) is *true*.
-		1. Let _result_ be ? Call(_onFinally_, *undefined*).
-		1. Let _C_ be _F_.[[Constructor]].
-		1. Assert: IsConstructor(_C_) is *true*.
-		1. Let _promise_ be ! PromiseResolve(_C_, _result_).
-		1. Let _thrower_ be equivalent to a function that throws _reason_.
-		1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_, *undefined* &raquo;).
-	</emu-alg>
+	<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
+		<h1>CatchFinally Function</h1>
+		<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
+		<p>When a CatchFinally function _F_ is called with argument _value_, the following steps are taken:</p>
+		<emu-alg>
+			1. Let _onFinally_ be _F_.[[OnFinally]].
+			1. Assert: IsCallable(_onFinally_) is *true*.
+			1. Let _result_ be ? Call(_onFinally_, *undefined*).
+			1. Let _C_ be _F_.[[Constructor]].
+			1. Assert: IsConstructor(_C_) is *true*.
+			1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+			1. Let _thrower_ be equivalent to a function that throws _reason_.
+			1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_, *undefined* &raquo;).
+		</emu-alg>
+	</emu-clause>
 </emu-clause>
 
 <!-- es6num="25.4.4.5" -->

--- a/spec.emu
+++ b/spec.emu
@@ -38,7 +38,7 @@ contributors: Jordan Harband
 			1. Let _result_ be ? Call(_onFinally_).
 			1. Let _C_ be _F_.[[Constructor]].
 			1. Assert: IsConstructor(_C_) is *true*.
-			1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+			1. Let _promise_ be ? PromiseResolve(_C_, _result_).
 			1. Let _valueThunk_ be equivalent to a function that returns _value_.
 			1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
 		</emu-alg>
@@ -54,7 +54,7 @@ contributors: Jordan Harband
 			1. Let _result_ be ? Call(_onFinally_).
 			1. Let _C_ be _F_.[[Constructor]].
 			1. Assert: IsConstructor(_C_) is *true*.
-			1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+			1. Let _promise_ be ? PromiseResolve(_C_, _result_).
 			1. Let _thrower_ be equivalent to a function that throws _reason_.
 			1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_ &raquo;).
 		</emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -15,37 +15,68 @@ contributors: Jordan Harband
 	<emu-alg>
 		1. Let _promise_ be the *this* value.
 		1. If IsPromise(_promise_) is *false*, throw a *TypeError* exception.
-		1. Let _thenFinally_ be ! CreateThenFinally(_onFinally_).
-		1. Let _catchFinally_ be ! CreateCatchFinally(_onFinally_).
+		1. Let _C_ be ? SpeciesConstructor(_promise_, %Promise%).
+		1. Let _thenFinally_ be ! CreateThenFinally(_C_, _onFinally_).
+		1. Let _catchFinally_ be ! CreateCatchFinally(_C_, _onFinally_).
 		1. Return ? Invoke(_promise_, `"then"`, &laquo; _thenFinally_, _catchFinally_ &raquo;).
 	</emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-createthenfinally" aoid="CreateThenFinally">
-	<h1>CreateThenFinally ( _onFinally_ )</h1>
-	<p>The abstract operation CreateThenFinally takes an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.</p>
+	<h1>CreateThenFinally ( _C_, _onFinally_ )</h1>
+	<p>The abstract operation CreateThenFinally takes a Promise Constructor _C_, and an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.</p>
 	<emu-alg>
+		1. Assert: IsConstructor(_C_) is *true*.
 		1. If IsCallable(_onFinally_) is not *true*, return _onFinally_.
-		1. Return a function that takes one argument, _value_, and when invoked, performs the following steps:
-			1. Let _result_ be ? Call(_onFinally_, *undefined*).
-			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
-			1. Let _valueThunk_ be equivalent to a function that returns _value_.
-			1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-			1. Return PerformPromiseThen(_promise_, _valueThunk_, *undefined*, _promiseCapability_).
+		1. Let _thenFinally_ be a new built-in function object as defined in <emu-xref href="#sec-thenfinallyfunction">ThenFinally Function</emu-xref>.
+		1. Set _thenFinally_.[[Constructor]] to _C_.
+		1. Set _thenFinally_.[[onFinally]] to _onFinally_.
+		1. Return _thenFinally_.
+	</emu-alg>
+</emu-clause>
+
+<emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
+	<h1>ThenFinally Function</h1>
+	<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+	<p>When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:</p>
+	<emu-alg>
+		1. Let _onFinally_ be _F_.[[onFinally]].
+		1. Assert: IsCallable(_onFinally_) is *true*.
+		1. Let _result_ be ? Call(_onFinally_, *undefined*).
+		1. Let _C_ be _F_.[[Constructor]].
+		1. Assert: IsConstructor(_C_) is *true*.
+		1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+		1. Let _valueThunk_ be equivalent to a function that returns _value_.
+		1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_, *undefined* &raquo;).
 	</emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-createcatchfinally" aoid="CreateCatchFinally">
-	<h1>CreateCatchFinally ( _onFinally_ )</h1>
+	<h1>CreateCatchFinally ( _C_, _onFinally_ )</h1>
 	<p>The abstract operation CreateThenFinally takes an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.</p>
 	<emu-alg>
+		1. Assert: IsConstructor(_C_) is *true*.
 		1. If IsCallable(_onFinally_) is not *true*, return _onFinally_.
-		1. Return a function that takes one argument, _reason_, and when invoked, performs the following steps:
-			1. Let _result_ be ? Call(_onFinally_, *undefined*).
-			1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
-			1. Let _thrower_ be equivalent to a function that throws _reason_.
-			1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-			1. Return PerformPromiseThen(_promise_, _thrower_, *undefined*, _promiseCapability_).
+		1. Let _catchFinally_ be a new built-in function object as defined in <emu-xref href="#sec-catchfinallyfunction">CatchFinally Function</emu-xref>.
+		1. Set _catchFinally_.[[Constructor]] to _C_.
+		1. Set _catchFinally_.[[onFinally]] to _onFinally_.
+		1. Return _catchFinally_.
+	</emu-alg>
+</emu-clause>
+
+<emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
+	<h1>CatchFinally Function</h1>
+	<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+	<p>When a CatchFinally function _F_ is called with argument _value_, the following steps are taken:</p>
+	<emu-alg>
+		1. Let _onFinally_ be _F_.[[onFinally]].
+		1. Assert: IsCallable(_onFinally_) is *true*.
+		1. Let _result_ be ? Call(_onFinally_, *undefined*).
+		1. Let _C_ be _F_.[[Constructor]].
+		1. Assert: IsConstructor(_C_) is *true*.
+		1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+		1. Let _thrower_ be equivalent to a function that throws _reason_.
+		1. Return ? Invoke(_promise_, `"then"`, &laquo; _thrower_, *undefined* &raquo;).
 	</emu-alg>
 </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -30,17 +30,17 @@ contributors: Jordan Harband
 		1. If IsCallable(_onFinally_) is not *true*, return _onFinally_.
 		1. Let _thenFinally_ be a new built-in function object as defined in <emu-xref href="#sec-thenfinallyfunction">ThenFinally Function</emu-xref>.
 		1. Set _thenFinally_.[[Constructor]] to _C_.
-		1. Set _thenFinally_.[[onFinally]] to _onFinally_.
+		1. Set _thenFinally_.[[OnFinally]] to _onFinally_.
 		1. Return _thenFinally_.
 	</emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-thenfinallyfunction" aoid="ThenFinallyFunction">
 	<h1>ThenFinally Function</h1>
-	<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+	<p>A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 	<p>When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:</p>
 	<emu-alg>
-		1. Let _onFinally_ be _F_.[[onFinally]].
+		1. Let _onFinally_ be _F_.[[OnFinally]].
 		1. Assert: IsCallable(_onFinally_) is *true*.
 		1. Let _result_ be ? Call(_onFinally_, *undefined*).
 		1. Let _C_ be _F_.[[Constructor]].
@@ -59,17 +59,17 @@ contributors: Jordan Harband
 		1. If IsCallable(_onFinally_) is not *true*, return _onFinally_.
 		1. Let _catchFinally_ be a new built-in function object as defined in <emu-xref href="#sec-catchfinallyfunction">CatchFinally Function</emu-xref>.
 		1. Set _catchFinally_.[[Constructor]] to _C_.
-		1. Set _catchFinally_.[[onFinally]] to _onFinally_.
+		1. Set _catchFinally_.[[OnFinally]] to _onFinally_.
 		1. Return _catchFinally_.
 	</emu-alg>
 </emu-clause>
 
 <emu-clause id="sec-catchfinallyfunction" aoid="CatchFinallyFunction">
 	<h1>CatchFinally Function</h1>
-	<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.</p>
+	<p>A CatchFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.</p>
 	<p>When a CatchFinally function _F_ is called with argument _value_, the following steps are taken:</p>
 	<emu-alg>
-		1. Let _onFinally_ be _F_.[[onFinally]].
+		1. Let _onFinally_ be _F_.[[OnFinally]].
 		1. Assert: IsCallable(_onFinally_) is *true*.
 		1. Let _result_ be ? Call(_onFinally_, *undefined*).
 		1. Let _C_ be _F_.[[Constructor]].

--- a/spec.md
+++ b/spec.md
@@ -21,12 +21,12 @@ A ThenFinally function is an anonymous built-in function that has a [[Constructo
 When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:
   1. Let _onFinally_ be _F_.[[OnFinally]].
   1. Assert: <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is *true*.
-  1. Let _result_ be ? Call(_onFinally_, *undefined*).
+  1. Let _result_ be ? Call(_onFinally_).
   1. Let _C_ be _F_.[[Constructor]].
   1. Assert: IsConstructor(_C_) is *true*.
   1. Let _promise_ be ! PromiseResolve(_C_, _result_).
   1. Let _valueThunk_ be equivalent to a function that returns _value_.
-  1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_, *undefined* &raquo;).
+  1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
 
 ### CatchFinally Function
 
@@ -35,12 +35,12 @@ A CatchFinally function is an anonymous built-in function that has a [[Construct
 When a CatchFinally function _F_ is called with argument _reason_, the following steps are taken:
   1. Let _onFinally_ be _F_.[[OnFinally]].
   1. Assert: <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is *true*.
-  1. Let _result_ be ? Call(_onFinally_, *undefined*).
+  1. Let _result_ be ? Call(_onFinally_).
   1. Let _C_ be _F_.[[Constructor]].
   1. Assert: IsConstructor(_C_) is *true*.
   1. Let _promise_ be ! PromiseResolve(_C_, _result_).
   1. Let _thrower_ be equivalent to a function that throws _reason_.
-  1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_, *undefined* &raquo;).
+  1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
 
 ## Promise.resolve ( _x_ )
 

--- a/spec.md
+++ b/spec.md
@@ -15,15 +15,15 @@ The abstract operation CreateThenFinally takes a Promise Constructor _C_, and an
   1. If <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is not *true*, return _onFinally_.
   1. Let _thenFinally_ be a new built-in function object as defined in ThenFinally Function.
   1. Set _thenFinally_.[[Constructor]] to _C_.
-  1. Set _thenFinally_.[[onFinally]] to _onFinally_.
+  1. Set _thenFinally_.[[OnFinally]] to _onFinally_.
   1. Return _thenFinally_.
 
 ## ThenFinally Function
 
-A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.
+A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.
 
 When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:
-  1. Let _onFinally_ be _F_.[[onFinally]].
+  1. Let _onFinally_ be _F_.[[OnFinally]].
   1. Assert: <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is *true*.
   1. Let _result_ be ? Call(_onFinally_, *undefined*).
   1. Let _C_ be _F_.[[Constructor]].

--- a/spec.md
+++ b/spec.md
@@ -9,25 +9,38 @@ When the `finally` method is called with argument _onFinally_, the following ste
 
 ## CreateThenFinally ( _onFinally_ )
 
-The abstract operation CreateCatchFinally takes an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.
-  1. If <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is not **true**, return _onFinally_.
-  1. Return a function that takes one argument, _value_, and when invoked, performs the following steps:
-    1. Let _result_ be ? Call(_onFinally_, *undefined*).
-    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
-    1. Let _valueThunk_ be equivalent to a function that returns _value_.
-    1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-    1. Return PerformPromiseThen(_promise_, _valueThunk_, *undefined*, _promiseCapability_).
+The abstract operation CreateThenFinally takes a Promise Constructor _C_, and an _onFinally_ function, and returns a callback function for use in `Promise.prototype.finally`.
+
+  1. Assert: IsConstructor(_C_) is *true*.
+  1. If <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is not *true*, return _onFinally_.
+  1. Let _thenFinally_ be a new built-in function object as defined in ThenFinally Function.
+  1. Set _thenFinally_.[[Constructor]] to _C_.
+  1. Set _thenFinally_.[[onFinally]] to _onFinally_.
+  1. Return _thenFinally_.
+
+## ThenFinally Function
+
+A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[onFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[onFinally]] internal slot is a function object.
+
+When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:
+  1. Let _onFinally_ be _F_.[[onFinally]].
+  1. Assert: <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is *true*.
+  1. Let _result_ be ? Call(_onFinally_, *undefined*).
+  1. Let _C_ be _F_.[[Constructor]].
+  1. Assert: IsConstructor(_C_) is *true*.
+  1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+  1. Let _valueThunk_ be equivalent to a function that returns _value_.
+  1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_, *undefined* &raquo;).
 
 ## CreateCatchFinally ( _onFinally_ )
 
-The abstract operation CreateCatchFinally takes an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.
-  1. If <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is not **true**, return _onFinally_.
-  1. Return a function that takes one argument, _reason_, and when invoked, performs the following steps:
-    1. Let _result_ be ? Call(_onFinally_, *undefined*).
-    1. Let _promise_ be ! PromiseResolve(%Promise%, _result_).
-    1. Let _thrower_ be equivalent to a function that throws _reason_.
-    1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-    1. Return PerformPromiseThen(_promise_, _thrower_, *undefined*, _promiseCapability_).
+The abstract operation CreateCatchFinally takes a Promise Constructor _C_, and an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.
+  1. Assert: IsConstructor(_C_) is *true*.
+  1. If <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is not *true*, return _onFinally_.
+  1. Let _catchFinally_ be a new built-in function object as defined in CatchFinally Function.
+  1. Set _catchFinally_.[[Constructor]] to _C_.
+  1. Set _catchFinally_.[[onFinally]] to _onFinally_.
+  1. Return _catchFinally_.
 
 ## Promise.resolve ( _x_ )
 

--- a/spec.md
+++ b/spec.md
@@ -20,7 +20,7 @@ The abstract operation CreateThenFinally takes a Promise Constructor _C_, and an
 
 ## ThenFinally Function
 
-A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a Promise constructor function object, and the value of the [[OnFinally]] internal slot is a function object.
+A ThenFinally function is an anonymous built-in function that has a [[Constructor]] and an [[OnFinally]] internal slot. The value of the [[Constructor]] internal slot is a `Promise`-like constructor function object, and the value of the [[OnFinally]] internal slot is a function object.
 
 When a ThenFinally function _F_ is called with argument _value_, the following steps are taken:
   1. Let _onFinally_ be _F_.[[OnFinally]].
@@ -34,7 +34,7 @@ When a ThenFinally function _F_ is called with argument _value_, the following s
 
 ## CreateCatchFinally ( _onFinally_ )
 
-The abstract operation CreateCatchFinally takes a Promise Constructor _C_, and an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.
+The abstract operation CreateCatchFinally takes a `Promise`-like constructor function _C_, and an _onFinally_ function, and returns a callback function for use in Promise.prototype.finally.
   1. Assert: IsConstructor(_C_) is *true*.
   1. If <a href="https://tc39.github.io/ecma262/#sec-iscallable">IsCallable</a>(_onFinally_) is not *true*, return _onFinally_.
   1. Let _catchFinally_ be a new built-in function object as defined in CatchFinally Function.

--- a/spec.md
+++ b/spec.md
@@ -24,7 +24,7 @@ When a ThenFinally function _F_ is called with argument _value_, the following s
   1. Let _result_ be ? Call(_onFinally_).
   1. Let _C_ be _F_.[[Constructor]].
   1. Assert: IsConstructor(_C_) is *true*.
-  1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+  1. Let _promise_ be ? PromiseResolve(_C_, _result_).
   1. Let _valueThunk_ be equivalent to a function that returns _value_.
   1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
 
@@ -38,7 +38,7 @@ When a CatchFinally function _F_ is called with argument _reason_, the following
   1. Let _result_ be ? Call(_onFinally_).
   1. Let _C_ be _F_.[[Constructor]].
   1. Assert: IsConstructor(_C_) is *true*.
-  1. Let _promise_ be ! PromiseResolve(_C_, _result_).
+  1. Let _promise_ be ? PromiseResolve(_C_, _result_).
   1. Let _thrower_ be equivalent to a function that throws _reason_.
   1. Return ? Invoke(_promise_, `"then"`, &laquo; _valueThunk_ &raquo;).
 

--- a/test/promise.js
+++ b/test/promise.js
@@ -2,7 +2,6 @@ global.foo = 0;
 global.id = 1;
 const {
 	Call,
-	EnqueueJob,
 	Get,
 	Invoke,
 	IsCallable,
@@ -20,455 +19,31 @@ const {
 } = require('especially/meta');
 const { '@@species': atAtSpecies } = require('especially/well-known-symbols');
 
-let PromiseIntrinsic;
+const {
+	PromiseIntrinsic,
+	NewPromiseCapability,
+	IsPromise,
+} = require('./promiseSpec');
 
-function IfAbruptRejectPromise(value, capability) {
-	// Usage: pass it exceptions; it only handles that case.
-	// Always use `return` before it, i.e. `try { ... } catch (e) { return IfAbruptRejectPromise(e, capability); }`.
-	Call(get_slot(capability, '[[Reject]]'), value);
-	return get_slot(capability, '[[Promise]]');
-}
-
-function CreateResolvingFunctions(promise) {
-	const alreadyResolved = {};
-	make_slots(alreadyResolved, [
-		'[[Value]]',
-	]);
-	set_slot(alreadyResolved, '[[Value]]', false);
-
-	function resolve(resolution) {
-		assert(has_slot(resolve, '[[Promise]]'));
-		const promise = get_slot(resolve, '[[Promise]]');
-		assert(Type(promise) === 'Object');
-
-		const alreadyResolved = get_slot(resolve, '[[AlreadyResolved]]');
-		if (get_slot(alreadyResolved, '[[Value]]') === true) {
-			return;
-		}
-
-		set_slot(alreadyResolved, '[[Value]]', true);
-
-		if (SameValue(resolution, promise) === true) {
-			const selfResolutionError = new TypeError('self resolution');
-			return RejectPromise(promise, selfResolutionError);
-		}
-
-		if (Type(resolution) !== 'Object') {
-			return FulfillPromise(promise, resolution);
-		}
-
-		let thenAction;
-		try {
-			thenAction = Get(resolution, 'then');
-		} catch (thenActionE) {
-			return RejectPromise(promise, thenActionE);
-		}
-
-		if (IsCallable(thenAction) === false) {
-			return FulfillPromise(promise, resolution);
-		}
-
-		EnqueueJob('PromiseJobs', PromiseResolveThenableJob, [promise, resolution, thenAction]);
-	}
-	make_slots(resolve, [
-		'[[Promise]]',
-		'[[AlreadyResolved]]',
-	]);
-	set_slot(resolve, '[[Promise]]', promise);
-	set_slot(resolve, '[[AlreadyResolved]]', alreadyResolved);
-
-	function reject(reason) {
-		assert(has_slot(reject, '[[Promise]]'));
-		const promise = get_slot(reject, '[[Promise]]');
-		assert(Type(promise) === 'Object');
-
-		const alreadyResolved = get_slot(reject, '[[AlreadyResolved]]');
-		if (get_slot(alreadyResolved, '[[Value]]') === true) {
-			return undefined;
-		}
-
-		set_slot(alreadyResolved, '[[Value]]', true);
-
-		return RejectPromise(promise, reason);
-	}
-	make_slots(reject, [
-		'[[Promise]]',
-		'[[AlreadyResolved]]',
-	]);
-	set_slot(reject, '[[Promise]]', promise);
-	set_slot(reject, '[[AlreadyResolved]]', alreadyResolved);
-
-	const record = {};
-	make_slots(record, [
-		'[[Resolve]]',
-		'[[Reject]]',
-	]);
-	set_slot(record, '[[Resolve]]', resolve);
-	set_slot(record, '[[Reject]]', reject);
-	return record;
-}
-
-function FulfillPromise(promise, value) {
-	assert(get_slot(promise, '[[PromiseState]]') === 'pending');
-
-	const reactions = get_slot(promise, '[[PromiseFulfillReactions]]');
-
-	set_slot(promise, '[[PromiseResult]]', value);
-	set_slot(promise, '[[PromiseFulfillReactions]]', undefined);
-	set_slot(promise, '[[PromiseRejectReactions]]', undefined);
-	set_slot(promise, '[[PromiseState]]', 'fulfilled');
-
-	return TriggerPromiseReactions(reactions, value);
-}
-
-function NewPromiseCapability(C) {
-	if (IsConstructor(C) === false) {
-		throw new TypeError('NewPromiseCapability only works on constructors');
-	}
-
-	const promiseCapability = {};
-	make_slots(promiseCapability, [
-		'[[Promise]]',
-		'[[Resolve]]',
-		'[[Reject]]',
-	]);
-	set_slot(promiseCapability, '[[Promise]]', undefined);
-	set_slot(promiseCapability, '[[Resolve]]', undefined);
-	set_slot(promiseCapability, '[[Reject]]', undefined);
-	function executor(resolve, reject) {
-		const promiseCapability = get_slot(executor, '[[Capability]]');
-
-		assert(IsPromiseCapabilityRecord(promiseCapability));
-
-		if (get_slot(promiseCapability, '[[Resolve]]') !== undefined) {
-			throw new TypeError('Promise capability must not have [[Resolve]] set when calling executor');
-		}
-		if (get_slot(promiseCapability, '[[Reject]]') !== undefined) {
-			throw new TypeError('Promise capability must not have [[Reject]] set when calling executor');
-		}
-
-		set_slot(promiseCapability, '[[Resolve]]', resolve);
-		set_slot(promiseCapability, '[[Reject]]', reject);
-
-		return undefined;
-	}
-	make_slots(executor, ['[[Capability]]']);
-	set_slot(executor, '[[Capability]]', promiseCapability);
-
-	const promise = new C(executor);
-	if (IsCallable(get_slot(promiseCapability, '[[Resolve]]')) === false) {
-		throw new TypeError('The given constructor did not correctly set a [[Resolve]] function on the promise capability');
-	}
-	if (IsCallable(get_slot(promiseCapability, '[[Reject]]')) === false) {
-		throw new TypeError('The given constructor did not correctly set a [[Reject]] function on the promise capability');
-	}
-
-	set_slot(promiseCapability, '[[Promise]]', promise);
-	return promiseCapability;
-}
-
-function IsPromiseCapabilityRecord(x) {
-	const promise = get_slot(x, '[[Promise]]');
-	if (promise !== undefined && !IsPromise(promise)) {
-		return false;
-	}
-
-	const resolve = get_slot(x, '[[Resolve]]');
-	const reject = get_slot(x, '[[Reject]]');
-	if (resolve !== undefined && !IsCallable(resolve)) {
-		return false;
-	}
-	if (reject !== undefined && !IsCallable(reject)) {
-		return false;
-	}
-
-	return true;
-}
-
-function IsPromiseReactionRecord(x) {
-	if (Type(x) !== 'Object') {
-		return false;
-	}
-
-	if (!has_slot(x, '[[Capability]]')) {
-		return false;
-	}
-	if (!has_slot(x, '[[Type]]')) {
-		return false;
-	}
-	const type = get_slot(x, '[[Type]]');
-	if (type !== 'Fulfill' && type !== 'Reject') {
-		return false;
-	}
-
-	if (!has_slot(x, '[[Handler]]')) {
-		return false;
-	}
-	const handler = get_slot(x, '[[Handler]]');
-	if (!IsCallable(handler) && handler !== undefined) {
-		return false;
-	}
-
-	return true;
-}
-
-function IsPromise(x) {
-	if (Type(x) !== 'Object') {
-		return false;
-	}
-
-	if (!has_slot(x, '[[PromiseState]]')) {
-		return false;
-	}
-
-	return true;
-}
-
-function RejectPromise(promise, reason) {
-	assert(get_slot(promise, '[[PromiseState]]') === 'pending');
-
-	const reactions = get_slot(promise, '[[PromiseRejectReactions]]');
-
-	set_slot(promise, '[[PromiseResult]]', reason);
-	set_slot(promise, '[[PromiseFulfillReactions]]', undefined);
-	set_slot(promise, '[[PromiseRejectReactions]]', undefined);
-	set_slot(promise, '[[PromiseState]]', 'rejected');
-
-	if (get_slot(promise, '[[PromiseIsHandled]]') === false) {
-		HostPromiseRejectionTracker(promise, 'reject');
-	}
-
-	return TriggerPromiseReactions(reactions, reason);
-}
-
-function TriggerPromiseReactions(reactions, argument) {
-	for (const reaction of reactions) {
-		EnqueueJob('PromiseJobs', PromiseReactionJob, [reaction, argument]);
-	}
-
-	return undefined;
-}
-
-function HostPromiseRejectionTracker(promise, operation) {
-	assert(IsPromise(promise));
-	assert(operation === 'reject' || operation === 'handle');
-}
-
-function NewCompletionRecord(type, value, target) {
-	const completionRecord = {};
-	make_slots(completionRecord, [
-		'[[Type]]',
-		'[[Value]]',
-		'[[Target]]',
-	]);
-	set_slot(completionRecord, '[[Type]]', type);
-	set_slot(completionRecord, '[[Value]]', value);
-	set_slot(completionRecord, '[[Target]]', target);
-	return completionRecord;
-}
-
-function isCompletionRecord(completionRecord) {
-	if (!has_slot(completionRecord, '[[Type]]') || !has_slot(completionRecord, '[[Value]]') || !has_slot(completionRecord, '[[Target]]')) {
-		return false;
-	}
-	const type = get_slot(completionRecord, '[[Type]]');
-	const possibleTypes = ['normal', 'break', 'continue', 'return', 'throw'];
-	if (!possibleTypes.includes(type)) {
-		return false;
-	}
-
-	const target = get_slot(completionRecord, '[[Target]]');
-	if (typeof target !== 'undefined' && typeof	target !== 'string') {
-		return false;
-	}
-	return true;
-}
-
-function NormalCompletion(value) {
-	return NewCompletionRecord('normal', value);
-}
-
-function AbruptCompletion(value) {
-	return NewCompletionRecord('throw', value);
-}
-
-function isAbruptCompletion(completionRecord) {
-	return isCompletionRecord(completionRecord) && get_slot(completionRecord, '[[Type]]') === 'throw';
-}
-
-function PromiseReactionJob(reaction, argument) {
-	assert(IsPromiseReactionRecord(reaction) === true);
-
-	const promiseCapability = get_slot(reaction, '[[Capability]]');
-	const type = get_slot(reaction, '[[Type]]');
-	const handler = get_slot(reaction, '[[Handler]]');
-
-	let handlerResult;
-	if (handler === undefined) {
-		if (type === 'Fulfill') {
-			handlerResult = NormalCompletion(argument);
-		} else {
-			assert(type === 'Reject');
-			handlerResult = AbruptCompletion(argument);
-		}
-	} else {
-		try {
-			handlerResult = NormalCompletion(Call(handler, undefined, [argument]));
-		} catch (callE) {
-			handlerResult = AbruptCompletion(callE);
-		}
-	}
-
-	let status;
-	if (isAbruptCompletion(handlerResult)) {
-		status = Call(get_slot(promiseCapability, '[[Reject]]'), undefined, [get_slot(handlerResult, '[[Value]]')]);
-	} else {
-		status = Call(get_slot(promiseCapability, '[[Resolve]]'), undefined, [get_slot(handlerResult, '[[Value]]')]);
-	}
-	return status;
-}
-
-function PromiseResolveThenableJob(promiseToResolve, thenable, then) {
-	const resolvingFunctions = CreateResolvingFunctions(promiseToResolve);
-
-	try {
-		Call(then, thenable, [
-			get_slot(resolvingFunctions, '[[Resolve]]'),
-			get_slot(resolvingFunctions, '[[Reject]]'),
-		]);
-	} catch (thenCallResultE) {
-		Call(get_slot(resolvingFunctions, '[[Reject]]'), undefined, [thenCallResultE]);
-	}
-}
-
-PromiseIntrinsic = class Promise {
-	constructor(executor) {
-		if (IsCallable(executor) === false) {
-			throw new TypeError('executor must be callable');
-		}
-
-		// Cheating a bit on NewTarget stuff here.
-
+Object.assign(PromiseIntrinsic.prototype, {
+	finally(onFinally) {
 		const promise = this;
-		make_slots(promise, [
-			'[[PromiseState]]',
-			'[[PromiseConstructor]]',
-			'[[PromiseResult]]',
-			'[[PromiseFulfillReactions]]',
-			'[[PromiseRejectReactions]]',
-			'[[PromiseIsHandled]]',
-		]);
-
-		set_slot(promise, '[[PromiseConstructor]]', this.constructor);
-		set_slot(promise, '[[PromiseState]]', 'pending');
-		set_slot(promise, '[[PromiseFulfillReactions]]', []);
-		set_slot(promise, '[[PromiseRejectReactions]]', []);
-		set_slot(promise, '[[PromiseIsHandled]]', false);
-		promise.id = global.id++;
-
-		const resolvingFunctions = CreateResolvingFunctions(promise);
-
-		try {
-			Call(executor, undefined, [
-				get_slot(resolvingFunctions, '[[Resolve]]'),
-				get_slot(resolvingFunctions, '[[Reject]]')
-			]);
-		} catch (completionE) {
-			Call(get_slot(resolvingFunctions, '[[Reject]]'), undefined, [completionE]);
+		if (IsPromise(this) === false) {
+			throw new TypeError('Promise.prototype.finally only works on real promises');
 		}
 
-		return promise;
+		const C = SpeciesConstructor(promise, PromiseIntrinsic);
+		const thenFinally = CreateThenFinally(C, onFinally);
+		const catchFinally = CreateCatchFinally(C, onFinally);
+
+		return promise.then(thenFinally, catchFinally);
 	}
-
-	static all(iterable) {
-		let C = this;
-
-		if (Type(C) !== 'Object') {
-			throw new TypeError('Promise.all must be called on an object');
-		}
-
-		const S = Get(C, atAtSpecies);
-		if (S !== undefined && S !== null) {
-			C = S;
-		}
-
-		// The algorithm and indirection here, with PerformPromiseAll, manual iteration, and the closure-juggling, is just
-		// too convoluted compared to normal ES code, so let's skip it. The following should be equivalent; it maintains
-		// some of the formal translation in places, but skips on some of the structure.
-
-		return new C((resolve, reject) => {
-			const values = [];
-
-			let remainingElementsCount = 1;
-			let index = 0;
-
-			for (const nextValue of iterable) {
-				values.push(undefined);
-				const nextPromise = Invoke(C, 'resolve', [nextValue]);
-
-				let alreadyCalled = false;
-				const resolveElement = x => {
-					if (alreadyCalled === true) {
-						return undefined;
-					}
-					alreadyCalled = true;
-					values[index] = x;
-
-					remainingElementsCount = remainingElementsCount - 1;
-					if (remainingElementsCount === 0) {
-						resolve(values);
-					}
-				};
-
-				remainingElementsCount = remainingElementsCount + 1;
-
-				Invoke(nextPromise, 'then', [resolveElement, reject]);
-
-				index += 1;
-			}
-		});
-	}
-
-	static race(iterable) {
-		let C = this;
-
-		if (Type(C) !== 'Object') {
-			throw new TypeError('Promise.all must be called on an object');
-		}
-
-		const S = Get(C, atAtSpecies);
-		if (S !== undefined && S !== null) {
-			C = S;
-		}
-
-		// Similarly to for `Promise.all`, we avoid some of the indirection here.
-
-		return new C((resolve, reject) => {
-			for (const nextValue of iterable) {
-				const nextPromise = Invoke(C, 'resolve', [nextValue]);
-				Invoke(nextPromise, 'then', [resolve, reject]);
-			}
-		});
-	}
-
-	static reject(r) {
-		let C = this;
-
-		if (Type(C) !== 'Object') {
-			throw new TypeError('Promise.all must be called on an object');
-		}
-
-		const S = Get(C, atAtSpecies);
-		if (S !== undefined && S !== null) {
-			C = S;
-		}
-
-		const promiseCapability = NewPromiseCapability(C);
-		Call(get_slot(promiseCapability, '[[Reject]]'), undefined, [r]);
-		return get_slot(promiseCapability, '[[Promise]]');
-	}
-
-	static resolve(x) {
+});
+Object.defineProperty(PromiseIntrinsic.prototype, 'finally', {
+	enumerable: false,
+});
+Object.assign(PromiseIntrinsic, {
+	resolve(x) {
 		let C = this;
 
 		if (Type(C) !== 'Object') {
@@ -484,38 +59,7 @@ PromiseIntrinsic = class Promise {
 
 		return PromiseResolve(C, x);
 	}
-
-	static get [atAtSpecies]() {
-		return this;
-	}
-
-	catch(onRejected) {
-		return Invoke(this, 'then', [undefined, onRejected]);
-	}
-
-	then(onFulfilled, onRejected) {
-		const promise = this;
-		if (IsPromise(this) === false) {
-			throw new TypeError('Promise.prototype.then only works on real promises');
-		}
-
-		const C = SpeciesConstructor(promise, Promise);
-		const resultCapability = NewPromiseCapability(C);
-		return PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability);
-	}
-
-	finally(onFinally) {
-		const promise = this;
-		if (IsPromise(this) === false) {
-			throw new TypeError('Promise.prototype.finally only works on real promises');
-		}
-
-		const thenFinally = CreateThenFinally(onFinally);
-		const catchFinally = CreateCatchFinally(onFinally);
-
-		return promise.then(thenFinally, catchFinally);
-	}
-}
+});
 
 function PromiseResolve(C, x) {
 	assert(Type(C) === 'Object');
@@ -525,94 +69,66 @@ function PromiseResolve(C, x) {
 	return get_slot(promiseCapability, '[[Promise]]');
 }
 
-function createPromiseReactionRecord(capability, type, handler) {
-	const record = {};
-	make_slots(record, [
-		'[[Capability]]',
-		'[[Type]]',
-		'[[Handler]]',
-	]);
-	set_slot(record, '[[Capability]]', capability);
-	set_slot(record, '[[Type]]', type);
-	set_slot(record, '[[Handler]]', handler);
-	return record;
-}
+function CreateThenFinally(C, onFinally) {
+	assert(IsConstructor(C));
 
-function PerformPromiseFinally(promise, onFinally, resultCapability) {
-	assert(IsPromise(promise) === true);
-	assert(IsPromiseCapabilityRecord(resultCapability) === true);
-
-	if (IsCallable(onFinally) === false) {
-		return PerformPromiseThen(promise, undefined, undefined, resultCapability);
-	}
-
-	const thenFinally = CreateThenFinally(onFinally);
-	const catchFinally = CreateCatchFinally(onFinally);
-
-	return PerformPromiseThen(promise, thenFinally, catchFinally, resultCapability);
-}
-
-function CreateThenFinally(onFinally) {
 	if (IsCallable(onFinally) !== true) {
 		return onFinally;
 	}
 
-	return (value) => {
+	const ThenFinally = (value) => {
+		const onFinally = get_slot(ThenFinally, 'onFinally');
+		assert(IsCallable(onFinally));
+
 		const result = onFinally();
-		const promise = PromiseResolve(PromiseIntrinsic, result);
+
+		const C = get_slot(ThenFinally, 'Constructor');
+		assert(IsConstructor(C));
+
+		const promise = PromiseResolve(C, result);
 		const valueThunk = () => value;
-		const promiseCapability = NewPromiseCapability(PromiseIntrinsic);
-		return PerformPromiseThen(promise, valueThunk, undefined, promiseCapability);
+		return Invoke(promise, 'then', [valueThunk]);
 	};
+
+	make_slots(ThenFinally, [
+		'onFinally',
+		'Constructor',
+	]);
+	set_slot(ThenFinally, 'onFinally', onFinally);
+	set_slot(ThenFinally, 'Constructor', C);
+
+	return ThenFinally;
 }
 
-function CreateCatchFinally(onFinally) {
+function CreateCatchFinally(C, onFinally) {
+	assert(IsConstructor(C));
+
 	if (IsCallable(onFinally) !== true) {
 		return onFinally;
 	}
 
-	return (reason) => {
+	const CatchFinally = (reason) => {
+		const onFinally = get_slot(CatchFinally, 'onFinally');
+		assert(IsCallable(onFinally));
+
 		const result = onFinally();
-		const promise = PromiseResolve(PromiseIntrinsic, result);
-		const throwReason = () => { throw reason; };
-		const promiseCapability = NewPromiseCapability(PromiseIntrinsic);
-		return PerformPromiseThen(promise, throwReason, undefined, promiseCapability);
+
+		const C = get_slot(CatchFinally, 'Constructor');
+		assert(IsConstructor(C));
+
+		const promise = PromiseResolve(C, result);
+		const thrower = () => { throw reason; };
+		return Invoke(promise, 'then', [thrower]);
 	};
-}
 
-function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability) {
-	assert(IsPromise(promise) === true);
-	assert(IsPromiseCapabilityRecord(resultCapability) === true);
+	make_slots(CatchFinally, [
+		'onFinally',
+		'Constructor',
+	]);
+	set_slot(CatchFinally, 'onFinally', onFinally);
+	set_slot(CatchFinally, 'Constructor', C);
 
-	if (IsCallable(onFulfilled) === false) {
-		onFulfilled = undefined;
-	}
-
-	if (IsCallable(onRejected) === false) {
-		onRejected = undefined;
-	}
-
-	const fulfillReaction = createPromiseReactionRecord(resultCapability, 'Fulfill', onFulfilled);
-	const rejectReaction = createPromiseReactionRecord(resultCapability, 'Reject', onRejected);
-
-	const state = get_slot(promise, '[[PromiseState]]');
-	if (state === 'pending') {
-		get_slot(promise, '[[PromiseFulfillReactions]]').push(fulfillReaction);
-		get_slot(promise, '[[PromiseRejectReactions]]').push(rejectReaction);
-	} else if (state === 'fulfilled') {
-		const value = get_slot(promise, '[[PromiseResult]]');
-		EnqueueJob('PromiseJobs', PromiseReactionJob, [fulfillReaction, value]);
-	} else {
-		assert(state === 'rejected');
-		const reason = get_slot(promise, '[[PromiseResult]]');
-		if (get_slot(promise, '[[PromiseIsHandled]]') === false) {
-			HostPromiseRejectionTracker(promise, 'handle');
-		}
-		EnqueueJob('PromiseJobs', PromiseReactionJob, [rejectReaction, reason]);
-	}
-
-	set_slot(promise, '[[PromiseIsHandled]]', true);
-	return get_slot(resultCapability, '[[Promise]]');
+	return CatchFinally;
 }
 
 module.exports = PromiseIntrinsic;

--- a/test/promise.js
+++ b/test/promise.js
@@ -77,7 +77,7 @@ function CreateThenFinally(C, onFinally) {
 	}
 
 	const ThenFinally = (value) => {
-		const onFinally = get_slot(ThenFinally, 'onFinally');
+		const onFinally = get_slot(ThenFinally, 'OnFinally');
 		assert(IsCallable(onFinally));
 
 		const result = onFinally();
@@ -91,10 +91,10 @@ function CreateThenFinally(C, onFinally) {
 	};
 
 	make_slots(ThenFinally, [
-		'onFinally',
+		'OnFinally',
 		'Constructor',
 	]);
-	set_slot(ThenFinally, 'onFinally', onFinally);
+	set_slot(ThenFinally, 'OnFinally', onFinally);
 	set_slot(ThenFinally, 'Constructor', C);
 
 	return ThenFinally;
@@ -108,7 +108,7 @@ function CreateCatchFinally(C, onFinally) {
 	}
 
 	const CatchFinally = (reason) => {
-		const onFinally = get_slot(CatchFinally, 'onFinally');
+		const onFinally = get_slot(CatchFinally, 'OnFinally');
 		assert(IsCallable(onFinally));
 
 		const result = onFinally();
@@ -122,10 +122,10 @@ function CreateCatchFinally(C, onFinally) {
 	};
 
 	make_slots(CatchFinally, [
-		'onFinally',
+		'OnFinally',
 		'Constructor',
 	]);
-	set_slot(CatchFinally, 'onFinally', onFinally);
+	set_slot(CatchFinally, 'OnFinally', onFinally);
 	set_slot(CatchFinally, 'Constructor', C);
 
 	return CatchFinally;

--- a/test/promiseSpec.js
+++ b/test/promiseSpec.js
@@ -1,0 +1,562 @@
+global.foo = 0;
+global.id = 1;
+const {
+  Call,
+  EnqueueJob,
+  Get,
+  Invoke,
+  IsCallable,
+  IsConstructor,
+  SameValue,
+  SpeciesConstructor,
+  Type,
+} = require('especially/abstract-operations');
+const {
+  assert,
+  get_slot,
+  has_slot,
+  make_slots,
+  set_slot,
+} = require('especially/meta');
+const { '@@species': atAtSpecies } = require('especially/well-known-symbols');
+
+let PromiseIntrinsic;
+
+function IfAbruptRejectPromise(value, capability) {
+  // Usage: pass it exceptions; it only handles that case.
+  // Always use `return` before it, i.e. `try { ... } catch (e) { return IfAbruptRejectPromise(e, capability); }`.
+  Call(get_slot(capability, '[[Reject]]'), value);
+  return get_slot(capability, '[[Promise]]');
+}
+
+function CreateResolvingFunctions(promise) {
+  const alreadyResolved = {};
+  make_slots(alreadyResolved, [
+    '[[Value]]',
+  ]);
+  set_slot(alreadyResolved, '[[Value]]', false);
+
+  function resolve(resolution) {
+    assert(has_slot(resolve, '[[Promise]]'));
+    const promise = get_slot(resolve, '[[Promise]]');
+    assert(Type(promise) === 'Object');
+
+    const alreadyResolved = get_slot(resolve, '[[AlreadyResolved]]');
+    if (get_slot(alreadyResolved, '[[Value]]') === true) {
+      return;
+    }
+
+    set_slot(alreadyResolved, '[[Value]]', true);
+
+    if (SameValue(resolution, promise) === true) {
+      const selfResolutionError = new TypeError('self resolution');
+      return RejectPromise(promise, selfResolutionError);
+    }
+
+    if (Type(resolution) !== 'Object') {
+      return FulfillPromise(promise, resolution);
+    }
+
+    let thenAction;
+    try {
+      thenAction = Get(resolution, 'then');
+    } catch (thenActionE) {
+      return RejectPromise(promise, thenActionE);
+    }
+
+    if (IsCallable(thenAction) === false) {
+      return FulfillPromise(promise, resolution);
+    }
+
+    EnqueueJob('PromiseJobs', PromiseResolveThenableJob, [promise, resolution, thenAction]);
+  }
+  make_slots(resolve, [
+    '[[Promise]]',
+    '[[AlreadyResolved]]',
+  ]);
+  set_slot(resolve, '[[Promise]]', promise);
+  set_slot(resolve, '[[AlreadyResolved]]', alreadyResolved);
+
+  function reject(reason) {
+    assert(has_slot(reject, '[[Promise]]'));
+    const promise = get_slot(reject, '[[Promise]]');
+    assert(Type(promise) === 'Object');
+
+    const alreadyResolved = get_slot(reject, '[[AlreadyResolved]]');
+    if (get_slot(alreadyResolved, '[[Value]]') === true) {
+      return undefined;
+    }
+
+    set_slot(alreadyResolved, '[[Value]]', true);
+
+    return RejectPromise(promise, reason);
+  }
+  make_slots(reject, [
+    '[[Promise]]',
+    '[[AlreadyResolved]]',
+  ]);
+  set_slot(reject, '[[Promise]]', promise);
+  set_slot(reject, '[[AlreadyResolved]]', alreadyResolved);
+
+  const record = {};
+  make_slots(record, [
+    '[[Resolve]]',
+    '[[Reject]]',
+  ]);
+  set_slot(record, '[[Resolve]]', resolve);
+  set_slot(record, '[[Reject]]', reject);
+  return record;
+}
+
+function FulfillPromise(promise, value) {
+  assert(get_slot(promise, '[[PromiseState]]') === 'pending');
+
+  const reactions = get_slot(promise, '[[PromiseFulfillReactions]]');
+
+  set_slot(promise, '[[PromiseResult]]', value);
+  set_slot(promise, '[[PromiseFulfillReactions]]', undefined);
+  set_slot(promise, '[[PromiseRejectReactions]]', undefined);
+  set_slot(promise, '[[PromiseState]]', 'fulfilled');
+
+  return TriggerPromiseReactions(reactions, value);
+}
+
+function NewPromiseCapability(C) {
+  if (IsConstructor(C) === false) {
+    throw new TypeError('NewPromiseCapability only works on constructors');
+  }
+
+  const promiseCapability = {};
+  make_slots(promiseCapability, [
+    '[[Promise]]',
+    '[[Resolve]]',
+    '[[Reject]]',
+  ]);
+  set_slot(promiseCapability, '[[Promise]]', undefined);
+  set_slot(promiseCapability, '[[Resolve]]', undefined);
+  set_slot(promiseCapability, '[[Reject]]', undefined);
+  function executor(resolve, reject) {
+    const promiseCapability = get_slot(executor, '[[Capability]]');
+
+    assert(IsPromiseCapabilityRecord(promiseCapability));
+
+    if (get_slot(promiseCapability, '[[Resolve]]') !== undefined) {
+      throw new TypeError('Promise capability must not have [[Resolve]] set when calling executor');
+    }
+    if (get_slot(promiseCapability, '[[Reject]]') !== undefined) {
+      throw new TypeError('Promise capability must not have [[Reject]] set when calling executor');
+    }
+
+    set_slot(promiseCapability, '[[Resolve]]', resolve);
+    set_slot(promiseCapability, '[[Reject]]', reject);
+
+    return undefined;
+  }
+  make_slots(executor, ['[[Capability]]']);
+  set_slot(executor, '[[Capability]]', promiseCapability);
+
+  const promise = new C(executor);
+  if (IsCallable(get_slot(promiseCapability, '[[Resolve]]')) === false) {
+    throw new TypeError('The given constructor did not correctly set a [[Resolve]] function on the promise capability');
+  }
+  if (IsCallable(get_slot(promiseCapability, '[[Reject]]')) === false) {
+    throw new TypeError('The given constructor did not correctly set a [[Reject]] function on the promise capability');
+  }
+
+  set_slot(promiseCapability, '[[Promise]]', promise);
+  return promiseCapability;
+}
+
+function IsPromiseCapabilityRecord(x) {
+  const promise = get_slot(x, '[[Promise]]');
+  if (promise !== undefined && !IsPromise(promise)) {
+    return false;
+  }
+
+  const resolve = get_slot(x, '[[Resolve]]');
+  const reject = get_slot(x, '[[Reject]]');
+  if (resolve !== undefined && !IsCallable(resolve)) {
+    return false;
+  }
+  if (reject !== undefined && !IsCallable(reject)) {
+    return false;
+  }
+
+  return true;
+}
+
+function IsPromiseReactionRecord(x) {
+  if (Type(x) !== 'Object') {
+    return false;
+  }
+
+  if (!has_slot(x, '[[Capability]]')) {
+    return false;
+  }
+  if (!has_slot(x, '[[Type]]')) {
+    return false;
+  }
+  const type = get_slot(x, '[[Type]]');
+  if (type !== 'Fulfill' && type !== 'Reject') {
+    return false;
+  }
+
+  if (!has_slot(x, '[[Handler]]')) {
+    return false;
+  }
+  const handler = get_slot(x, '[[Handler]]');
+  if (!IsCallable(handler) && handler !== undefined) {
+    return false;
+  }
+
+  return true;
+}
+
+function IsPromise(x) {
+  if (Type(x) !== 'Object') {
+    return false;
+  }
+
+  if (!has_slot(x, '[[PromiseState]]')) {
+    return false;
+  }
+
+  return true;
+}
+
+function RejectPromise(promise, reason) {
+  assert(get_slot(promise, '[[PromiseState]]') === 'pending');
+
+  const reactions = get_slot(promise, '[[PromiseRejectReactions]]');
+
+  set_slot(promise, '[[PromiseResult]]', reason);
+  set_slot(promise, '[[PromiseFulfillReactions]]', undefined);
+  set_slot(promise, '[[PromiseRejectReactions]]', undefined);
+  set_slot(promise, '[[PromiseState]]', 'rejected');
+
+  if (get_slot(promise, '[[PromiseIsHandled]]') === false) {
+    HostPromiseRejectionTracker(promise, 'reject');
+  }
+
+  return TriggerPromiseReactions(reactions, reason);
+}
+
+function TriggerPromiseReactions(reactions, argument) {
+  for (const reaction of reactions) {
+    EnqueueJob('PromiseJobs', PromiseReactionJob, [reaction, argument]);
+  }
+
+  return undefined;
+}
+
+function HostPromiseRejectionTracker(promise, operation) {
+  assert(IsPromise(promise));
+  assert(operation === 'reject' || operation === 'handle');
+}
+
+function NewCompletionRecord(type, value, target) {
+  const completionRecord = {};
+  make_slots(completionRecord, [
+    '[[Type]]',
+    '[[Value]]',
+    '[[Target]]',
+  ]);
+  set_slot(completionRecord, '[[Type]]', type);
+  set_slot(completionRecord, '[[Value]]', value);
+  set_slot(completionRecord, '[[Target]]', target);
+  return completionRecord;
+}
+
+function isCompletionRecord(completionRecord) {
+  if (!has_slot(completionRecord, '[[Type]]') || !has_slot(completionRecord, '[[Value]]') || !has_slot(completionRecord, '[[Target]]')) {
+    return false;
+  }
+  const type = get_slot(completionRecord, '[[Type]]');
+  const possibleTypes = ['normal', 'break', 'continue', 'return', 'throw'];
+  if (!possibleTypes.includes(type)) {
+    return false;
+  }
+
+  const target = get_slot(completionRecord, '[[Target]]');
+  if (typeof target !== 'undefined' && typeof target !== 'string') {
+    return false;
+  }
+  return true;
+}
+
+function NormalCompletion(value) {
+  return NewCompletionRecord('normal', value);
+}
+
+function AbruptCompletion(value) {
+  return NewCompletionRecord('throw', value);
+}
+
+function isAbruptCompletion(completionRecord) {
+  return isCompletionRecord(completionRecord) && get_slot(completionRecord, '[[Type]]') === 'throw';
+}
+
+function PromiseReactionJob(reaction, argument) {
+  assert(IsPromiseReactionRecord(reaction) === true);
+
+  const promiseCapability = get_slot(reaction, '[[Capability]]');
+  const type = get_slot(reaction, '[[Type]]');
+  const handler = get_slot(reaction, '[[Handler]]');
+
+  let handlerResult;
+  if (handler === undefined) {
+    if (type === 'Fulfill') {
+      handlerResult = NormalCompletion(argument);
+    } else {
+      assert(type === 'Reject');
+      handlerResult = AbruptCompletion(argument);
+    }
+  } else {
+    try {
+      handlerResult = NormalCompletion(Call(handler, undefined, [argument]));
+    } catch (callE) {
+      handlerResult = AbruptCompletion(callE);
+    }
+  }
+
+  let status;
+  if (isAbruptCompletion(handlerResult)) {
+    status = Call(get_slot(promiseCapability, '[[Reject]]'), undefined, [get_slot(handlerResult, '[[Value]]')]);
+  } else {
+    status = Call(get_slot(promiseCapability, '[[Resolve]]'), undefined, [get_slot(handlerResult, '[[Value]]')]);
+  }
+  return status;
+}
+
+function PromiseResolveThenableJob(promiseToResolve, thenable, then) {
+  const resolvingFunctions = CreateResolvingFunctions(promiseToResolve);
+
+  try {
+    Call(then, thenable, [
+      get_slot(resolvingFunctions, '[[Resolve]]'),
+      get_slot(resolvingFunctions, '[[Reject]]'),
+    ]);
+  } catch (thenCallResultE) {
+    Call(get_slot(resolvingFunctions, '[[Reject]]'), undefined, [thenCallResultE]);
+  }
+}
+
+PromiseIntrinsic = class Promise {
+  constructor(executor) {
+    if (IsCallable(executor) === false) {
+      throw new TypeError('executor must be callable');
+    }
+
+    // Cheating a bit on NewTarget stuff here.
+
+    const promise = this;
+    make_slots(promise, [
+      '[[PromiseState]]',
+      '[[PromiseConstructor]]',
+      '[[PromiseResult]]',
+      '[[PromiseFulfillReactions]]',
+      '[[PromiseRejectReactions]]',
+      '[[PromiseIsHandled]]',
+    ]);
+
+    set_slot(promise, '[[PromiseConstructor]]', this.constructor);
+    set_slot(promise, '[[PromiseState]]', 'pending');
+    set_slot(promise, '[[PromiseFulfillReactions]]', []);
+    set_slot(promise, '[[PromiseRejectReactions]]', []);
+    set_slot(promise, '[[PromiseIsHandled]]', false);
+    promise.id = global.id++;
+
+    const resolvingFunctions = CreateResolvingFunctions(promise);
+
+    try {
+      Call(executor, undefined, [
+        get_slot(resolvingFunctions, '[[Resolve]]'),
+        get_slot(resolvingFunctions, '[[Reject]]')
+      ]);
+    } catch (completionE) {
+      Call(get_slot(resolvingFunctions, '[[Reject]]'), undefined, [completionE]);
+    }
+
+    return promise;
+  }
+
+  static all(iterable) {
+    let C = this;
+
+    if (Type(C) !== 'Object') {
+      throw new TypeError('Promise.all must be called on an object');
+    }
+
+    const S = Get(C, atAtSpecies);
+    if (S !== undefined && S !== null) {
+      C = S;
+    }
+
+    // The algorithm and indirection here, with PerformPromiseAll, manual iteration, and the closure-juggling, is just
+    // too convoluted compared to normal ES code, so let's skip it. The following should be equivalent; it maintains
+    // some of the formal translation in places, but skips on some of the structure.
+
+    return new C((resolve, reject) => {
+      const values = [];
+
+      let remainingElementsCount = 1;
+      let index = 0;
+
+      for (const nextValue of iterable) {
+        values.push(undefined);
+        const nextPromise = Invoke(C, 'resolve', [nextValue]);
+
+        let alreadyCalled = false;
+        const resolveElement = x => {
+          if (alreadyCalled === true) {
+            return undefined;
+          }
+          alreadyCalled = true;
+          values[index] = x;
+
+          remainingElementsCount = remainingElementsCount - 1;
+          if (remainingElementsCount === 0) {
+            resolve(values);
+          }
+        };
+
+        remainingElementsCount = remainingElementsCount + 1;
+
+        Invoke(nextPromise, 'then', [resolveElement, reject]);
+
+        index += 1;
+      }
+    });
+  }
+
+  static race(iterable) {
+    let C = this;
+
+    if (Type(C) !== 'Object') {
+      throw new TypeError('Promise.all must be called on an object');
+    }
+
+    const S = Get(C, atAtSpecies);
+    if (S !== undefined && S !== null) {
+      C = S;
+    }
+
+    // Similarly to for `Promise.all`, we avoid some of the indirection here.
+
+    return new C((resolve, reject) => {
+      for (const nextValue of iterable) {
+        const nextPromise = Invoke(C, 'resolve', [nextValue]);
+        Invoke(nextPromise, 'then', [resolve, reject]);
+      }
+    });
+  }
+
+  static reject(r) {
+    let C = this;
+
+    if (Type(C) !== 'Object') {
+      throw new TypeError('Promise.all must be called on an object');
+    }
+
+    const S = Get(C, atAtSpecies);
+    if (S !== undefined && S !== null) {
+      C = S;
+    }
+
+    const promiseCapability = NewPromiseCapability(C);
+    Call(get_slot(promiseCapability, '[[Reject]]'), undefined, [r]);
+    return get_slot(promiseCapability, '[[Promise]]');
+  }
+
+  static resolve(x) {
+    let C = this;
+
+    if (Type(C) !== 'Object') {
+      throw new TypeError('Promise.all must be called on an object');
+    }
+
+    if (IsPromise(x) === true) {
+      const xConstructor = Get(x, 'constructor');
+      if (SameValue(xConstructor, C) === true) {
+        return x;
+      }
+    }
+
+    const promiseCapability = NewPromiseCapability(C);
+    Call(get_slot(promiseCapability, '[[Resolve]]'), undefined, [x]);
+    return get_slot(promiseCapability, '[[Promise]]');
+  }
+
+  static get [atAtSpecies]() {
+    return this;
+  }
+
+  catch(onRejected) {
+    return Invoke(this, 'then', [undefined, onRejected]);
+  }
+
+  then(onFulfilled, onRejected) {
+    const promise = this;
+    if (IsPromise(this) === false) {
+      throw new TypeError('Promise.prototype.then only works on real promises');
+    }
+
+    const C = SpeciesConstructor(promise, PromiseIntrinsic);
+    const resultCapability = NewPromiseCapability(C);
+    return PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability);
+  }
+}
+
+function createPromiseReactionRecord(capability, type, handler) {
+  const record = {};
+  make_slots(record, [
+    '[[Capability]]',
+    '[[Type]]',
+    '[[Handler]]',
+  ]);
+  set_slot(record, '[[Capability]]', capability);
+  set_slot(record, '[[Type]]', type);
+  set_slot(record, '[[Handler]]', handler);
+  return record;
+}
+
+function PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability) {
+  assert(IsPromise(promise) === true);
+  assert(IsPromiseCapabilityRecord(resultCapability) === true);
+
+  if (IsCallable(onFulfilled) === false) {
+    onFulfilled = undefined;
+  }
+
+  if (IsCallable(onRejected) === false) {
+    onRejected = undefined;
+  }
+
+  const fulfillReaction = createPromiseReactionRecord(resultCapability, 'Fulfill', onFulfilled);
+  const rejectReaction = createPromiseReactionRecord(resultCapability, 'Reject', onRejected);
+
+  const state = get_slot(promise, '[[PromiseState]]');
+  if (state === 'pending') {
+    get_slot(promise, '[[PromiseFulfillReactions]]').push(fulfillReaction);
+    get_slot(promise, '[[PromiseRejectReactions]]').push(rejectReaction);
+  } else if (state === 'fulfilled') {
+    const value = get_slot(promise, '[[PromiseResult]]');
+    EnqueueJob('PromiseJobs', PromiseReactionJob, [fulfillReaction, value]);
+  } else {
+    assert(state === 'rejected');
+    const reason = get_slot(promise, '[[PromiseResult]]');
+    if (get_slot(promise, '[[PromiseIsHandled]]') === false) {
+      HostPromiseRejectionTracker(promise, 'handle');
+    }
+    EnqueueJob('PromiseJobs', PromiseReactionJob, [rejectReaction, reason]);
+  }
+
+  set_slot(promise, '[[PromiseIsHandled]]', true);
+  return get_slot(resultCapability, '[[Promise]]');
+}
+
+module.exports = {
+  PromiseIntrinsic,
+  NewPromiseCapability,
+  IsPromise,
+};


### PR DESCRIPTION
 - Use SpeciesConstructor to ensure subclasses are respected
 - Observably invoke `.then` with the result of the `onFinally` function
 - Refactor closures to use the more verbose form the spec currently favors.

Fixes #29. Fixes #32. Fixes #33.

------------------------------

This should hopefully address all three issues at once. I also refactored the promise tests so the pre-proposal stuff is in a separate file.