### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Many promise libraries have a "finally" method, for registering a callback to be
  - When creating a function inline, you can pass it once, instead of being forced to either declare it twice, or create a variable for it
  - A `finally` callback will not receive any argument, since there's no reliable means of determining if the promise was fulfilled or rejected. This use case is for precisely when you *do not care* about the rejection reason, or the fulfillment value, and so there's no need to provide it.
  - Unlike `Promise.resolve(2).then(() => {}, () => {})` (which will be resolved with `undefined`), `Promise.resolve(2).finally(() => {})` will be resolved with `2`.
- - Similarly, unlike `Promise.reject(3).then(() => {}, () => {})` (which will be resolved with `undefined`), `Promise.reject(3).finally(() => {})` will be rejected with `3`.
+ - Similarly, unlike `Promise.reject(3).then(() => {}, () => {})` (which will be rejected with `undefined`), `Promise.reject(3).finally(() => {})` will be rejected with `3`.
 
 However, please note: a `throw` (or returning a rejected promise) in the `finally` callback will reject the new promise with that rejection reason.
 


### PR DESCRIPTION
`resolved` --> `rejected`