### PR TITLE
fix(test): fix #45, fix return a fulfilled-after-a-second case

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -300,13 +300,13 @@ describe('onFinally', () => {
 					return new P((resolve, reject) => {
 						setTimeout(() => reject(4), 1e3);
 					});
-				}).then(function onFulfilled(x) {
-					clearTimeout(timeout);
-					assert.strictEqual(x, 3);
-					done();
-				}, function onRejected() {
+				}).then(function onFulfilled() {
 					clearTimeout(timeout);
 					done(new Error('should not be called'));
+				}, function onRejected(e) {
+					clearTimeout(timeout);
+					assert.strictEqual(e, 4);
+					done();
 				});
 		});
 


### PR DESCRIPTION
Fixes #45.

Modify a test case behavior.
I think the following behavior is correct. Current behavior is `then.onResolved` is called.

```javascript
adapter.resolved(3)
  .then((x) => {
      assert.strictEqual(x, 3);
      return x;
  })
  .finally(function onFinally() {
     assert(arguments.length === 0);
     setTimeout(done, 1.5e3);
     return new P((resolve, reject) => {
	setTimeout(() => reject(4), 1e3);
     });
  }).then(function onFulfilled(x) {
     assert.strictEqual(x, 3);
  }, function onRejected() {
     throw new Error('should not be called'); 
  });
```

The `onFinally` return `promise` will` reject` itself after 1 second, so the following `then` should also call `onRejected` not `onResolved`.