### PR TITLE
Explicit species constructor logic unnecessary?

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -3,43 +3,36 @@ if (typeof Promise !== 'function') {
 }
 
 if (typeof Promise.prototype.finally !== 'function') {
-	var speciesConstructor = function (O, defaultConstructor) {
-		if (!O || (typeof O !== 'object' && typeof O !== 'function')) {
-			throw new TypeError('Assertion failed: Type(O) is not Object');
-		}
-		var C = O.constructor;
-		if (typeof C === 'undefined') {
-			return defaultConstructor;
-		}
-		if (!C || (typeof C !== 'object' && typeof C !== 'function')) {
-			throw new TypeError('O.constructor is not an Object');
-		}
-		var S = typeof Symbol === 'function' && typeof Symbol.species === 'symbol' ? C[Symbol.species] : undefined;
-		if (S == null) {
-			return defaultConstructor;
-		}
-		if (typeof S === 'function' && S.prototype) {
-			return S;
-		}
-		throw new TypeError('no constructor found');
-	};
-
-	var shim = {
-		finally(onFinally) {
+	Object.defineProperty(Promise.prototype, 'finally', {
+		configurable: true,
+		writable: true,
+		value(onFinally) {
 			var promise = this;
 			if (typeof promise !== 'object' || promise === null) {
 				throw new TypeError('"this" value is not an Object');
 			}
-			var C = speciesConstructor(promise, Promise); // throws if SpeciesConstructor throws
 			if (typeof onFinally !== 'function') {
 				return Promise.prototype.then.call(promise, onFinally, onFinally);
 			}
+			var threw = false;
+			var result;
 			return Promise.prototype.then.call(
 				promise,
-				x => new C(resolve => resolve(onFinally())).then(() => x),
-				e => new C(resolve => resolve(onFinally())).then(() => { throw e; })
-			);
+				function (x) {
+					result = x;
+					return onFinally();
+				},
+				function (e) {
+					threw = true;
+					result = e;
+					return onFinally();
+				}
+			).then(function () {
+				if (threw) {
+					throw result;
+				}
+				return result;
+			});
 		}
-	};
-	Object.defineProperty(Promise.prototype, 'finally', { configurable: true, writable: true, value: shim.finally });
+	});
 }


### PR DESCRIPTION
In order to be tolerant of `Promise` subclassing, polyfill implementations of `Promise.prototype.finally` typically implement logic to obtain the species constructor `C`, which is then used to call `C.resolve(onFinally())` or `new C(resolve => resolve(onFinally())` to ensure the resolved promise is `instanceof` the custom subclass.

However, a polyfill implementation of `Promise.prototype.finally` that does not need to call `resolve` explicitly could potentially avoid this extra effort to obtain the appropriate species constructor. If this new implementation is truly equivalent (modulo any fixable problems that I may have overlooked), then spec-compliant polyfills would no longer incur a penalty for following the spec exactly, compared to naive implementations that ignore these details for the sake of simplicity.

This pull request demonstrates one such implementation. Here's the essential logic:

```js
var threw = false;
var result;
return Promise.prototype.then.call(
  this,
  function (value) {
    result = value;
    return onFinally();
  },
  function (error) {
    threw = true;
    result = error;
    return onFinally();
  }
).then(function () {
  if (threw) throw result;
  return result;
});
```

The trick is to return the result of `onFinally()` from the `.then` callback functions, which automatically resolves the return value to an instance of the current `Promise` subclass, using whatever resolution logic the subclass implements. The final `.then` will be invoked against an instance of the subclass, allowing the subclass to define the behavior of `.then` and thus the final result of the `.finally` method.

Note that a spec-compliant implementation of `Promise.prototype.then` will almost certainly still need to obtain the species constructor in its own implementation. However, it seems desirable to keep that logic out of `Promise.prototype.finally` if possible.

After considering this implementation, if you still believe the explicit species constructor logic is necessary, I would encourage you to write a test that demonstrates the difference.

If there are no objections to this new implementation, this repository seems like the appropriate place to provide updated guidance to other implementations. In other words, if this PR is merged, I will gladly submit PRs to other implementations, referring back to this PR.